### PR TITLE
Fix backspace behavior

### DIFF
--- a/lib/suggestion-list.coffee
+++ b/lib/suggestion-list.coffee
@@ -70,6 +70,9 @@ class SuggestionList
   onDidCancel: (fn) ->
     @emitter.on('did-cancel', fn)
 
+  isActive: ->
+    @active
+
   show: (editor) =>
     return if @active
     return unless editor?

--- a/spec/autocomplete-manager-integration-spec.coffee
+++ b/spec/autocomplete-manager-integration-spec.coffee
@@ -296,6 +296,7 @@ describe 'Autocomplete Manager', ->
           # Accept suggestion
           key = atom.keymaps.constructor.buildKeydownEvent('down', {target: document.activeElement})
           atom.keymaps.handleKeyboardEvent(key)
+          advanceClock(1)
 
           autocomplete = editorView.querySelector('.autocomplete-plus')
           expect(autocomplete).not.toExist()
@@ -321,6 +322,7 @@ describe 'Autocomplete Manager', ->
           # Accept suggestion
           key = atom.keymaps.constructor.buildKeydownEvent('down', {target: document.activeElement})
           atom.keymaps.handleKeyboardEvent(key)
+          advanceClock(1)
 
           autocomplete = editorView.querySelector('.autocomplete-plus')
           expect(autocomplete).not.toExist()
@@ -356,6 +358,7 @@ describe 'Autocomplete Manager', ->
           # Accept suggestion
           key = atom.keymaps.constructor.buildKeydownEvent('up', {target: document.activeElement})
           atom.keymaps.handleKeyboardEvent(key)
+          advanceClock(1)
 
           autocomplete = editorView.querySelector('.autocomplete-plus')
           expect(autocomplete).not.toExist()
@@ -381,6 +384,7 @@ describe 'Autocomplete Manager', ->
           # Accept suggestion
           key = atom.keymaps.constructor.buildKeydownEvent('up', {target: document.activeElement})
           atom.keymaps.handleKeyboardEvent(key)
+          advanceClock(1)
 
           autocomplete = editorView.querySelector('.autocomplete-plus')
           expect(autocomplete).not.toExist()

--- a/spec/autocomplete-manager-integration-spec.coffee
+++ b/spec/autocomplete-manager-integration-spec.coffee
@@ -113,16 +113,19 @@ describe 'Autocomplete Manager', ->
         runs ->
           expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
 
-      it 'should show the suggestion list when backspacing', ->
+      it "keeps the suggestion list open when it's already open on backspace", ->
         expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
 
         # Trigger an autocompletion
         editor.moveToBottom()
-        editor.insertText('fu')
+        editor.insertText('f')
+        editor.insertText('u')
 
         waitForAutocomplete()
 
         runs ->
+          expect(editorView.querySelector('.autocomplete-plus')).toExist()
+
           key = atom.keymaps.constructor.buildKeydownEvent('backspace', {target: document.activeElement})
           atom.keymaps.handleKeyboardEvent(key)
 
@@ -131,6 +134,21 @@ describe 'Autocomplete Manager', ->
         runs ->
           expect(editorView.querySelector('.autocomplete-plus')).toExist()
           expect(editor.lineTextForBufferRow(13)).toBe('f')
+
+      it "does not open the suggestion on backspace when it's closed", ->
+        expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+
+        # Trigger an autocompletion
+        editor.setCursorBufferPosition([2, 39]) # at the end of `items`
+
+        runs ->
+          key = atom.keymaps.constructor.buildKeydownEvent('backspace', {target: document.activeElement})
+          atom.keymaps.handleKeyboardEvent(key)
+
+          waitForAutocomplete()
+
+        runs ->
+          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
 
       it 'should not update the suggestion list while composition is in progress', ->
         triggerAutocompletion(editor)


### PR DESCRIPTION
The backspace behavior has been really frustrating for me. I've made it so backspace cannot trigger a display, but it will stay open during backspace operations. Also, previously, it would flash (hide, then show again) on backspace, which was annoying. 

Old
![old-backspace](https://cloud.githubusercontent.com/assets/69169/6012580/99f6b818-aafe-11e4-8d85-0699699c2c1c.gif)

New
![new-backspace](https://cloud.githubusercontent.com/assets/69169/6012584/a2ffcd1e-aafe-11e4-9003-ed938288ee38.gif)
