### PR TITLE
Use a 0 delay when the suggestion list is active

### DIFF
--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -212,6 +212,7 @@ class AutocompleteManager
   contentsModified: =>
     delay = atom.config.get('autocomplete-plus.autoActivationDelay')
     clearTimeout(@delayTimeout)
+    delay = 0 if @suggestionList.active
     @delayTimeout = setTimeout(@runAutocompletion, delay)
 
   # Private: Gets called when the cursor has moved. Cancels the autocompletion if


### PR DESCRIPTION
The `autoActivationDelay` is the delay before displaying the list, but it is being used for an update of the results as well. When the suggestion list is open, this will use a 0 delay. It feels considerably snappier. 