### PR TITLE
Don’t show suggestions when they are triggered but no longer needed

### DIFF
--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -209,10 +209,13 @@ class AutocompleteManager
     return false
 
   # Private: Gets called when the content has been modified
-  contentsModified: =>
+  requestNewSuggestions: =>
     delay = atom.config.get('autocomplete-plus.autoActivationDelay')
     clearTimeout(@delayTimeout)
     @delayTimeout = setTimeout(@runAutocompletion, delay)
+
+  clearNewSuggestionsRequest: ->
+    clearTimeout(@delayTimeout)
 
   # Private: Gets called when the cursor has moved. Cancels the autocompletion if
   # the text has not been changed.
@@ -232,8 +235,9 @@ class AutocompleteManager
   # event - The change {Event}
   bufferChanged: ({newText, oldText}) =>
     return if @suggestionList.compositionInProgress
+    @clearNewSuggestionsRequest()
     if atom.config.get('autocomplete-plus.enableAutoActivation') and (newText.trim().length is 1 or oldText.trim().length is 1)
-      @contentsModified()
+      @requestNewSuggestions()
     else
       @hideSuggestionList()
 

--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -214,7 +214,7 @@ class AutocompleteManager
     clearTimeout(@delayTimeout)
     @delayTimeout = setTimeout(@runAutocompletion, delay)
 
-  clearNewSuggestionsRequest: ->
+  cancelNewSuggestionsRequest: ->
     clearTimeout(@delayTimeout)
 
   # Private: Gets called when the cursor has moved. Cancels the autocompletion if
@@ -235,7 +235,7 @@ class AutocompleteManager
   # event - The change {Event}
   bufferChanged: ({newText, oldText}) =>
     return if @suggestionList.compositionInProgress
-    @clearNewSuggestionsRequest()
+    @cancelNewSuggestionsRequest()
     if atom.config.get('autocomplete-plus.enableAutoActivation') and (newText.trim().length is 1 or oldText.trim().length is 1)
       @requestNewSuggestions()
     else

--- a/spec/autocomplete-manager-integration-spec.coffee
+++ b/spec/autocomplete-manager-integration-spec.coffee
@@ -86,7 +86,7 @@ describe 'Autocomplete Manager', ->
         runs ->
           expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
 
-    describe 'on changed events', ->
+    describe 'when the buffer changes', ->
       it 'should show the suggestion list when suggestions are found', ->
         expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
 
@@ -151,6 +151,17 @@ describe 'Autocomplete Manager', ->
           document.activeElement.dispatchEvent(buildTextInputEvent({data: 'ã', target: document.activeElement}))
 
           expect(editor.lineTextForBufferRow(13)).toBe('fã')
+
+      it 'does not show the suggestion list when it is triggered then no longer needed', ->
+        editor.moveToBottom()
+        editor.insertText('f')
+        editor.insertText('u')
+        editor.insertText(' ')
+
+        waitForAutocomplete()
+
+        runs ->
+          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
 
     describe 'accepting suggestions', ->
       it 'hides the suggestions list when a suggestion is confirmed', ->


### PR DESCRIPTION
![race-condition-old](https://cloud.githubusercontent.com/assets/69169/6013284/6bc2f372-ab07-11e4-96b2-497cd384b30d.gif)

This only fixes half the issue. Truly async providers will have the same problem. I'm thinking about how to solve it in that case...