### PR TITLE
Show cursor while autocompleting

### DIFF
--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -249,8 +249,6 @@ class AutocompleteManager
   #
   # event - The change {Event}
   bufferChanged: ({newText, oldText}) =>
-    return if @suggestionList.compositionInProgress
-
     autoActivationEnabled = atom.config.get('autocomplete-plus.enableAutoActivation')
     wouldAutoActivate = newText.trim().length is 1 or ((@backspaceTriggersAutocomplete or @suggestionList.isActive()) and oldText.trim().length is 1)
 

--- a/lib/suggestion-list-element.coffee
+++ b/lib/suggestion-list-element.coffee
@@ -11,9 +11,12 @@ class SuggestionListElement extends HTMLElement
     @registerMouseHandling()
 
   attachedCallback: ->
-    @renderInput() unless @input
+    @addActiveClassToEditor()
     @renderList() unless @ol
     @itemsChanged()
+
+  detachedCallback: ->
+    @removeActiveClassFromEditor()
 
   initialize: (@model) ->
     return unless model?
@@ -42,9 +45,14 @@ class SuggestionListElement extends HTMLElement
   itemsChanged: ->
     @selectedIndex = 0
     @renderItems()
-    setTimeout =>
-      @input.focus()
-    , 0
+
+  addActiveClassToEditor: ->
+    editorElement = atom.views.getView(atom.workspace.getActiveTextEditor())
+    editorElement.classList.add 'autocomplete-active'
+
+  removeActiveClassFromEditor: ->
+    editorElement = atom.views.getView(atom.workspace.getActiveTextEditor())
+    editorElement.classList.add 'autocomplete-active'
 
   moveSelectionUp: ->
     unless @selectedIndex <= 0
@@ -79,18 +87,6 @@ class SuggestionListElement extends HTMLElement
       @model.confirm(item)
     else
       @model.cancel()
-
-  renderInput: ->
-    @input = document.createElement('input')
-    @appendChild(@input)
-
-    @input.addEventListener 'compositionstart', =>
-      @model.compositionInProgress = true
-      null
-
-    @input.addEventListener 'compositionend', =>
-      @model.compositionInProgress = false
-      null
 
   renderList: ->
     @ol = document.createElement('ol')

--- a/lib/suggestion-list.coffee
+++ b/lib/suggestion-list.coffee
@@ -8,7 +8,7 @@ class SuggestionList
     @emitter = new Emitter
     @subscriptions = new CompositeDisposable
     # Allow keyboard navigation of the suggestion list
-    @subscriptions.add(atom.commands.add 'autocomplete-suggestion-list',
+    @subscriptions.add(atom.commands.add 'atom-text-editor.autocomplete-active',
       'autocomplete-plus:confirm': @confirmSelection,
       'autocomplete-plus:select-next': @selectNext,
       'autocomplete-plus:select-previous': @selectPrevious,
@@ -33,7 +33,7 @@ class SuggestionList
       keys['ctrl-n'] = 'autocomplete-plus:select-next'
       keys['ctrl-p'] = 'autocomplete-plus:select-previous'
 
-    @keymaps = atom.keymaps.add('autocomplete-suggestion-list', {'atom-text-editor:not(.mini) .autocomplete-plus': keys})
+    @keymaps = atom.keymaps.add('atom-text-editor.autocomplete-active', {'atom-text-editor.autocomplete-active': keys})
 
     @subscriptions.add(@keymaps)
 

--- a/lib/suggestion-list.coffee
+++ b/lib/suggestion-list.coffee
@@ -4,7 +4,6 @@ module.exports =
 class SuggestionList
   constructor: ->
     @active = false
-    @compositionInProgress = false
     @emitter = new Emitter
     @subscriptions = new CompositeDisposable
     # Allow keyboard navigation of the suggestion list

--- a/spec/autocomplete-manager-integration-spec.coffee
+++ b/spec/autocomplete-manager-integration-spec.coffee
@@ -223,20 +223,23 @@ describe 'Autocomplete Manager', ->
       it 'should not update the suggestion list while composition is in progress', ->
         triggerAutocompletion(editor)
 
+        # unfortunately, we need to fire IME events from the editor's input node so the editor picks them up
+        activeElement = editorView.rootElement.querySelector('input')
+
         runs ->
           spyOn(autocompleteManager.suggestionList, 'changeItems').andCallThrough()
           expect(autocompleteManager.suggestionList.changeItems).not.toHaveBeenCalled()
 
-          document.activeElement.dispatchEvent(buildIMECompositionEvent('compositionstart', {target: document.activeElement}))
-          document.activeElement.dispatchEvent(buildIMECompositionEvent('compositionupdate', {data: '~', target: document.activeElement}))
+          activeElement.dispatchEvent(buildIMECompositionEvent('compositionstart', {target: activeElement}))
+          activeElement.dispatchEvent(buildIMECompositionEvent('compositionupdate', {data: '~', target: activeElement}))
 
           waitForAutocomplete()
 
         runs ->
           expect(autocompleteManager.suggestionList.changeItems).not.toHaveBeenCalled()
 
-          document.activeElement.dispatchEvent(buildIMECompositionEvent('compositionend', {target: document.activeElement}))
-          document.activeElement.dispatchEvent(buildTextInputEvent({data: 'ã', target: document.activeElement}))
+          activeElement.dispatchEvent(buildIMECompositionEvent('compositionend', {target: activeElement}))
+          activeElement.dispatchEvent(buildTextInputEvent({data: 'ã', target: activeElement}))
 
           expect(editor.lineTextForBufferRow(13)).toBe('fã')
 


### PR DESCRIPTION
This PR subscribes to the events on the editor with a special class: `atom-text-editor.autocomplete-active`. So autocomplete will never receive focus. Since the editor retains focus, the cursor continues to blink. 

This PR has the added benefit of removing the input from the the suggestion list element. Less moving parts, and we can use the IME handling code from core, rather than our own. 

![autocomplete-show-cursor](https://cloud.githubusercontent.com/assets/69169/6030309/7f3d9732-abab-11e4-868a-bbe25cc89227.gif)