### PR TITLE
#210 fix IME support issue

### DIFF
--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -42,11 +42,11 @@ class AutocompleteManager
     @shouldAbortSuggestions = false
 
     # This's a workaroung, we should ask Atom to emit events like `onCompositionDidStart`
-    editor = $('atom-text-editor')[0]
-    editor.addEventListener 'compositionstart', =>
+    editor = $('atom-text-editor')
+    editor.on 'compositionstart', ->
       self.shouldAbortSuggestions = true
 
-    editor.addEventListener 'compositionend', =>
+    editor.on 'compositionend', ->
       self.shouldAbortSuggestions = false
 
   updateCurrentEditor: (currentPaneItem) =>


### PR DESCRIPTION
This PR is aimed at #210.

For now, the only to detect if composition window is showed (means typing with IME) is to use [composition events](https://developer.mozilla.org/en-US/docs/Web/API/CompositionEvent). But unfortunately, Atom doesn't emit those events. So I have to listen to the DOM directly. It's not a perfect solution, but works:

![demo](https://cloud.githubusercontent.com/assets/189559/6055685/2055d686-ad3f-11e4-8eb0-b77f38477016.gif)
