### PR TITLE
Consume Snippets API

### DIFF
--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -169,6 +169,8 @@ class AutocompleteManager
 
     @replaceTextWithMatch(match)
 
+    # FIXME: move this to the snippet provider's onDidInsertSuggestion() method
+    # when the API has been updated.
     if match.isSnippet
       setTimeout =>
         atom.commands.dispatch(atom.views.getView(@editor), 'snippets:expand')
@@ -207,10 +209,10 @@ class AutocompleteManager
         @editor.selectLeft(match.prefix.length)
         @editor.delete()
 
-      if @snippetsManager?
-        @snippetsManager.insertSnippet(match.word, @editor)
+      if match.snippet? and @snippetsManager?
+        @snippetsManager.insertSnippet(match.snippet, @editor)
       else
-        @editor.insertText(match.word)
+        @editor.insertText(match.word ? match.snippet)
 
   # Private: Checks whether the current file is blacklisted.
   #

--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -37,6 +37,8 @@ class AutocompleteManager
     @subscriptions.add(@suggestionList) # We're adding this last so it is disposed after events
     @ready = true
 
+  setSnippetsManager: (@snippetsManager) ->
+
   updateCurrentEditor: (currentPaneItem) =>
     return if not currentPaneItem? or currentPaneItem is @editor
 
@@ -205,7 +207,10 @@ class AutocompleteManager
         @editor.selectLeft(match.prefix.length)
         @editor.delete()
 
-      @editor.insertText(match.word)
+      if @snippetsManager?
+        @snippetsManager.insertSnippet(match.word, @editor)
+      else
+        @editor.insertText(match.word)
 
   # Private: Checks whether the current file is blacklisted.
   #

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -152,5 +152,5 @@ module.exports =
           registration?.dispose?()
       )
 
-  consumeSnippets: (snippets) ->
-    @getAutocompleteManager().snippets = snippets
+  consumeSnippets: (snippetsManager) ->
+    @getAutocompleteManager().setSnippetsManager(snippetsManager)

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -151,3 +151,6 @@ module.exports =
         for registration in registrations
           registration?.dispose?()
       )
+
+  consumeSnippets: (snippets) ->
+    @getAutocompleteManager().snippets = snippets

--- a/lib/suggestion-list-element.coffee
+++ b/lib/suggestion-list-element.coffee
@@ -127,7 +127,7 @@ class SuggestionListElement extends HTMLElement
         wordSpan.className = 'word'
 
       replacement = word
-      if snippet?
+      if _.isString(snippet)
         replacement = snippet.replace @snippetRegex, (match, snippetText) ->
           "<span class=\"snippet-completion\">#{snippetText}</span>"
 

--- a/lib/suggestion-list-element.coffee
+++ b/lib/suggestion-list-element.coffee
@@ -108,7 +108,7 @@ class SuggestionListElement extends HTMLElement
 
   renderItems: ->
     items = @visibleItems() or []
-    items.forEach ({word, label, renderLabelAsHtml, className, prefix}, index) =>
+    items.forEach ({snippet, word, label, renderLabelAsHtml, className, prefix}, index) =>
       li = @ol.childNodes[index]
       unless li
         li = document.createElement('li')
@@ -126,22 +126,24 @@ class SuggestionListElement extends HTMLElement
         li.appendChild(wordSpan)
         wordSpan.className = 'word'
 
-      word = word.replace @snippetRegex, (match, snippetText) ->
-        "<span class=\"snippet-completion\">#{snippetText}</span>"
+      replacement = word
+      if snippet?
+        replacement = snippet.replace @snippetRegex, (match, snippetText) ->
+          "<span class=\"snippet-completion\">#{snippetText}</span>"
 
       # highlight the prefix
       displayHtml = ''
       wordIndex = 0
       lastWordIndex = 0
       for ch, i in prefix
-        while wordIndex < word.length and word[wordIndex].toLowerCase() isnt ch.toLowerCase()
+        while wordIndex < replacement.length and replacement[wordIndex].toLowerCase() isnt ch.toLowerCase()
           wordIndex += 1
-        preChar = word.substring(lastWordIndex, wordIndex)
-        highlightedChar = "<span class=\"character-match\">#{word[wordIndex]}</span>"
+        preChar = replacement.substring(lastWordIndex, wordIndex)
+        highlightedChar = "<span class=\"character-match\">#{replacement[wordIndex]}</span>"
         displayHtml = "#{displayHtml}#{preChar}#{highlightedChar}"
         wordIndex += 1
         lastWordIndex = wordIndex
-      displayHtml += word.substring(lastWordIndex)
+      displayHtml += replacement.substring(lastWordIndex)
       wordSpan.innerHTML = displayHtml
 
       labelSpan = li.childNodes[1]

--- a/lib/suggestion-list-element.coffee
+++ b/lib/suggestion-list-element.coffee
@@ -3,6 +3,7 @@ _ = require('underscore-plus')
 
 class SuggestionListElement extends HTMLElement
   maxItems: 1000
+  snippetRegex: /\$\{[0-9]+:([^}]+)\}/g
 
   createdCallback: ->
     @subscriptions = new CompositeDisposable
@@ -125,15 +126,23 @@ class SuggestionListElement extends HTMLElement
         li.appendChild(wordSpan)
         wordSpan.className = 'word'
 
-      wordSpan.innerHTML = ("<span>#{ch}</span>" for ch in word).join('')
+      word = word.replace @snippetRegex, (match, snippetText) ->
+        "<span class=\"snippet-completion\">#{snippetText}</span>"
 
       # highlight the prefix
+      displayHtml = ''
       wordIndex = 0
+      lastWordIndex = 0
       for ch, i in prefix
         while wordIndex < word.length and word[wordIndex].toLowerCase() isnt ch.toLowerCase()
           wordIndex += 1
-        wordSpan.childNodes[wordIndex]?.classList.add('character-match')
+        preChar = word.substring(lastWordIndex, wordIndex)
+        highlightedChar = "<span class=\"character-match\">#{word[wordIndex]}</span>"
+        displayHtml = "#{displayHtml}#{preChar}#{highlightedChar}"
         wordIndex += 1
+        lastWordIndex = wordIndex
+      displayHtml += word.substring(lastWordIndex)
+      wordSpan.innerHTML = displayHtml
 
       labelSpan = li.childNodes[1]
       if label

--- a/package.json
+++ b/package.json
@@ -28,6 +28,11 @@
         "1.0.0": "consumeProvider",
         "1.1.0": "consumeProviders"
       }
+    },
+    "snippets": {
+      "versions": {
+        "0.73.0": "consumeSnippets"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     },
     "snippets": {
       "versions": {
-        "0.73.0": "consumeSnippets"
+        "0.1.0": "consumeSnippets"
       }
     }
   }

--- a/spec/autocomplete-manager-integration-spec.coffee
+++ b/spec/autocomplete-manager-integration-spec.coffee
@@ -2,6 +2,8 @@
 _ = require('underscore-plus')
 {KeymapManager} = require('atom')
 
+NodeTypeText = 3
+
 describe 'Autocomplete Manager', ->
   [workspaceElement, completionDelay, editorView, editor, mainModule, autocompleteManager, mainModule] = []
 
@@ -309,10 +311,10 @@ describe 'Autocomplete Manager', ->
           word = editorView.querySelector('.autocomplete-plus li span.word')
           expect(word.childNodes).toHaveLength 5
           expect(word.childNodes[0]).toHaveClass 'character-match'
-          expect(word.childNodes[1]).not.toHaveClass 'character-match'
+          expect(word.childNodes[1].nodeType).toBe NodeTypeText
           expect(word.childNodes[2]).toHaveClass 'character-match'
           expect(word.childNodes[3]).toHaveClass 'character-match'
-          expect(word.childNodes[4]).not.toHaveClass 'character-match'
+          expect(word.childNodes[4].nodeType).toBe NodeTypeText
 
       it 'highlights repeated characters in the prefix', ->
         expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
@@ -328,12 +330,12 @@ describe 'Autocomplete Manager', ->
           expect(editorView.querySelector('.autocomplete-plus')).toExist()
 
           word = editorView.querySelector('.autocomplete-plus li span.word')
-          expect(word.childNodes).toHaveLength 5
+          expect(word.childNodes).toHaveLength 4
           expect(word.childNodes[0]).toHaveClass 'character-match'
           expect(word.childNodes[1]).toHaveClass 'character-match'
           expect(word.childNodes[2]).toHaveClass 'character-match'
-          expect(word.childNodes[3]).not.toHaveClass 'character-match'
-          expect(word.childNodes[4]).not.toHaveClass 'character-match'
+          expect(word.childNodes[3].nodeType).toBe 3 # text
+          expect(word.childNodes[3].textContent).toBe 'ly'
 
     describe 'accepting suggestions', ->
       it 'hides the suggestions list when a suggestion is confirmed', ->

--- a/spec/autocomplete-manager-integration-spec.coffee
+++ b/spec/autocomplete-manager-integration-spec.coffee
@@ -78,7 +78,7 @@ describe 'Autocomplete Manager', ->
             expect(wordElement.textContent).toBe 'method(something)'
             expect(wordElement.querySelector('.snippet-completion').textContent).toBe 'something'
 
-        it "accepts the ", ->
+        it "accepts the snippet when autocomplete-plus:confirm is triggered", ->
           triggerAutocompletion(editor, true, 'm')
 
           runs ->

--- a/styles/autocomplete.less
+++ b/styles/autocomplete.less
@@ -30,19 +30,21 @@ autocomplete-suggestion-list.select-list.popover-list {
         font-weight: bold;
         color: @text-color-highlight;
       }
-      &.selected .character-match {
-        color:@text-color-selected;
-      }
       .snippet-completion {
         color: @text-color-subtle;
-      }
-      &.selected .completion-label {
-        color: fadeout(@text-color-selected, 60%);
       }
       .completion-label {
         float: right;
         padding-right: 6px;
         padding-left: 6px;
+      }
+      &.selected {
+        .character-match {
+          color: @text-color-selected;
+        }
+        .completion-label, .snippet-completion {
+          color: fadeout(@text-color-selected, 60%);
+        }
       }
     }
   }

--- a/styles/autocomplete.less
+++ b/styles/autocomplete.less
@@ -33,6 +33,9 @@ autocomplete-suggestion-list.select-list.popover-list {
       &.selected .character-match {
         color:@text-color-selected;
       }
+      .snippet-completion {
+        color: @text-color-subtle;
+      }
       &.selected .completion-label {
         color: fadeout(@text-color-selected, 60%);
       }


### PR DESCRIPTION
Merge when atom 0.183.0 is out

This PR seeks to integrate autocomplete-plus with [snippets](https://github.com/atom/snippets) such that snippets.insert can be used to dynamically insert anonymous snippets into the current editor. This will allow autocomplete-plus providers to include anonymous snippets as part of their suggestions, giving a richer experience (particularly when confirming a suggestion which is a function, allowing us to expand the arguments automatically and allow the user to tab through them).

See https://github.com/atom/snippets/pull/106 / https://github.com/atom/snippets/pull/110

- [x] Consume Snippets API
- [x] Allow insertion of anonymous snippets from suggestions
- [x] Specs
