### PR TITLE
Add better support for CSS properties*

### DIFF
--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -149,7 +149,8 @@ class AutocompleteManager
 
   prefixForCursor: (cursor) =>
     return '' unless @buffer? and cursor?
-    start = cursor.getBeginningOfCurrentWordBufferPosition()
+    regex = new RegExp(cursor.wordRegExp().source.replace(/\\\-/g, ''), 'g')
+    start = cursor.getBeginningOfCurrentWordBufferPosition({ wordRegex: regex })
     end = cursor.getBufferPosition()
     return '' unless start? and end?
     @buffer.getTextInRange(new Range(start, end))


### PR DESCRIPTION
\* or any words containing dashes, really.

- Dynamically remove ```\-``` from the default word definition regex as it treats words containing ```-``` as two, causing broken completion.