### PR TITLE
Fix engines field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Display possible completions in the editor while typing",
   "repository": "https://github.com/atom-community/autocomplete-plus",
   "engines": {
-    "atom": ">=0.177.0*"
+    "atom": ">=0.177.0 <2.0.0"
   },
   "dependencies": {
     "async": ">=0.9.0",


### PR DESCRIPTION
Remove `*` to reduce confusion, and add make sure atom is less than `2.0.0`.