### PR TITLE
Use @text-color-selected instead

### DIFF
--- a/styles/autocomplete.less
+++ b/styles/autocomplete.less
@@ -29,7 +29,7 @@ autocomplete-suggestion-list.select-list.popover-list {
       }
       .character-match {
         font-weight: bold;
-        color: @text-color-highlight;
+        color: @text-color-selected;
       }
       &.selected .completion-label {
         color: @text-color;


### PR DESCRIPTION
Atom uses the @background-color-selected on selected list-group items, this plugin should use the corresponding text color for selection.