### PR TITLE
Max visible suggestions option

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -17,7 +17,7 @@ module.exports =
       type: 'integer'
       default: 100
       order: 2
-    maxSuggestions:
+    maxVisibleSuggestions:
       title: 'Maximum Visible Suggestions'
       description: 'The autocomplete popup will only show this many suggestions.'
       type: 'integer'
@@ -105,6 +105,13 @@ module.exports =
 
   # Public: Creates AutocompleteManager instances for all active and future editors (soon, just a single AutocompleteManager)
   activate: ->
+    # Upgrade to the new config key name
+    oldMax = atom.config.get('autocomplete-plus.maxSuggestions')
+    if oldMax isnt 10
+      atom.config.transact ->
+        atom.config.set('autocomplete-plus.maxVisibleSuggestions', oldMax)
+        atom.config.unset('autocomplete-plus.maxSuggestions')
+
     @getAutocompleteManager()
     # @activateTimeout = setTimeout(@getAutocompleteManager, 0)
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -18,33 +18,26 @@ module.exports =
       default: 100
       order: 2
     maxSuggestions:
-      title: 'Maximum Suggestions'
-      description: 'The list of suggestions will be limited to this number.'
-      type: 'integer'
-      default: 200
-      minimum: 1
-      order: 3
-    maxVisibleSuggestions:
       title: 'Maximum Visible Suggestions'
       description: 'The autocomplete popup will only show this many suggestions.'
       type: 'integer'
       default: 10
       minimum: 1
-      order: 4
+      order: 3
     confirmCompletion:
       title: 'Keymap For Confirming A Suggestion'
       description: 'You should use the key(s) indicated here to confirm a suggestion from the suggestion list and have it inserted into the file.'
       type: 'string'
       default: 'tab'
       enum: ['tab', 'enter', 'tab and enter']
-      order: 5
+      order: 4
     navigateCompletions:
       title: 'Keymap For Navigating The Suggestion List'
       description: 'You should use the keys indicated here to select suggestions in the suggestion list (moving up or down).'
       type: 'string'
       default: 'up,down'
       enum: ['up,down', 'ctrl-p,ctrl-n']
-      order: 6
+      order: 5
     fileBlacklist:
       title: 'File Blacklist'
       description: 'Suggestions will not be provided for files matching this list.'
@@ -52,7 +45,7 @@ module.exports =
       default: ['.*']
       items:
         type: 'string'
-      order: 7
+      order: 6
     scopeBlacklist:
       title: 'Scope Blacklist'
       description: 'Suggestions will not be provided for scopes matching this list. See: https://atom.io/docs/latest/advanced/scopes-and-scope-descriptors'
@@ -60,55 +53,55 @@ module.exports =
       default: []
       items:
         type: 'string'
-      order: 8
+      order: 7
     includeCompletionsFromAllBuffers:
       title: 'Include Completions From All Buffers'
       description: 'For grammars with no registered provider(s), FuzzyProvider will include completions from all buffers, instead of just the buffer you are currently editing.'
       type: 'boolean'
       default: false
-      order: 9
+      order: 8
     strictMatching:
       title: 'Use Strict Matching For Built-In Provider'
       description: 'Fuzzy searching is performed if this is disabled; if it is enabled, suggestions must begin with the prefix from the current word.'
       type: 'boolean'
       default: false
-      order: 10
+      order: 9
     minimumWordLength:
       description: "Only autocomplete when you've typed at least this many characters."
       type: 'integer'
       default: 1
-      order: 11
+      order: 10
     enableBuiltinProvider:
       title: 'Enable Built-In Provider'
       description: 'The package comes with a built-in provider that will provide suggestions using the words in your current buffer or all open buffers. You will get better suggestions by installing additional autocomplete+ providers. To stop using the built-in provider, disable this option.'
       type: 'boolean'
       default: true
-      order: 12
+      order: 11
     builtinProviderBlacklist:
       title: 'Built-In Provider Blacklist'
       description: 'Don\'t use the built-in provider for these selector(s).'
       type: 'string'
       default: '.source.gfm'
-      order: 13
+      order: 12
     backspaceTriggersAutocomplete:
       title: 'Allow Backspace To Trigger Autocomplete'
       description: 'If enabled, typing `backspace` will show the suggestion list if suggestions are available. If disabled, suggestions will not be shown while backspacing.'
       type: 'boolean'
       default: true
-      order: 14
+      order: 13
     suggestionListFollows:
       title: 'Suggestions List Follows'
       description: 'With "Cursor" the suggestion list appears at the cursor\'s position. With "Word" it appers at the beginning of the word that\'s being completed.'
       type: 'string'
       default: 'Cursor'
       enum: ['Cursor', 'Word']
-      order: 15
+      order: 14
     defaultProvider:
       description: 'Using the Symbol provider is experimental. You must reload Atom to use a new provider after changing this option.'
       type: 'string'
       default: 'Fuzzy'
       enum: ['Fuzzy', 'Symbol']
-      order: 16
+      order: 15
 
   # Public: Creates AutocompleteManager instances for all active and future editors (soon, just a single AutocompleteManager)
   activate: ->

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -21,22 +21,30 @@ module.exports =
       title: 'Maximum Suggestions'
       description: 'The list of suggestions will be limited to this number.'
       type: 'integer'
-      default: 10
+      default: 200
+      minimum: 1
       order: 3
+    maxVisibleSuggestions:
+      title: 'Maximum Visible Suggestions'
+      description: 'The autocomplete popup will only show this many suggestions.'
+      type: 'integer'
+      default: 10
+      minimum: 1
+      order: 4
     confirmCompletion:
       title: 'Keymap For Confirming A Suggestion'
       description: 'You should use the key(s) indicated here to confirm a suggestion from the suggestion list and have it inserted into the file.'
       type: 'string'
       default: 'tab'
       enum: ['tab', 'enter', 'tab and enter']
-      order: 4
+      order: 5
     navigateCompletions:
       title: 'Keymap For Navigating The Suggestion List'
       description: 'You should use the keys indicated here to select suggestions in the suggestion list (moving up or down).'
       type: 'string'
       default: 'up,down'
       enum: ['up,down', 'ctrl-p,ctrl-n']
-      order: 5
+      order: 6
     fileBlacklist:
       title: 'File Blacklist'
       description: 'Suggestions will not be provided for files matching this list.'
@@ -44,7 +52,7 @@ module.exports =
       default: ['.*']
       items:
         type: 'string'
-      order: 6
+      order: 7
     scopeBlacklist:
       title: 'Scope Blacklist'
       description: 'Suggestions will not be provided for scopes matching this list. See: https://atom.io/docs/latest/advanced/scopes-and-scope-descriptors'
@@ -52,55 +60,55 @@ module.exports =
       default: []
       items:
         type: 'string'
-      order: 7
+      order: 8
     includeCompletionsFromAllBuffers:
       title: 'Include Completions From All Buffers'
       description: 'For grammars with no registered provider(s), FuzzyProvider will include completions from all buffers, instead of just the buffer you are currently editing.'
       type: 'boolean'
       default: false
-      order: 8
+      order: 9
     strictMatching:
       title: 'Use Strict Matching For Built-In Provider'
       description: 'Fuzzy searching is performed if this is disabled; if it is enabled, suggestions must begin with the prefix from the current word.'
       type: 'boolean'
       default: false
-      order: 9
+      order: 10
     minimumWordLength:
       description: "Only autocomplete when you've typed at least this many characters."
       type: 'integer'
       default: 1
-      order: 10
+      order: 11
     enableBuiltinProvider:
       title: 'Enable Built-In Provider'
       description: 'The package comes with a built-in provider that will provide suggestions using the words in your current buffer or all open buffers. You will get better suggestions by installing additional autocomplete+ providers. To stop using the built-in provider, disable this option.'
       type: 'boolean'
       default: true
-      order: 10
+      order: 12
     builtinProviderBlacklist:
       title: 'Built-In Provider Blacklist'
       description: 'Don\'t use the built-in provider for these selector(s).'
       type: 'string'
       default: '.source.gfm'
-      order: 11
+      order: 13
     backspaceTriggersAutocomplete:
       title: 'Allow Backspace To Trigger Autocomplete'
       description: 'If enabled, typing `backspace` will show the suggestion list if suggestions are available. If disabled, suggestions will not be shown while backspacing.'
       type: 'boolean'
       default: true
-      order: 12
+      order: 14
     suggestionListFollows:
       title: 'Suggestions List Follows'
       description: 'With "Cursor" the suggestion list appears at the cursor\'s position. With "Word" it appers at the beginning of the word that\'s being completed.'
       type: 'string'
       default: 'Cursor'
       enum: ['Cursor', 'Word']
-      order: 13
+      order: 15
     defaultProvider:
       description: 'Using the Symbol provider is experimental. You must reload Atom to use a new provider after changing this option.'
       type: 'string'
       default: 'Fuzzy'
       enum: ['Fuzzy', 'Symbol']
-      order: 14
+      order: 16
 
   # Public: Creates AutocompleteManager instances for all active and future editors (soon, just a single AutocompleteManager)
   activate: ->

--- a/lib/suggestion-list-element.coffee
+++ b/lib/suggestion-list-element.coffee
@@ -2,12 +2,11 @@
 _ = require('underscore-plus')
 
 class SuggestionListElement extends HTMLElement
-  maxItems: 10
+  maxItems: 1000
 
   createdCallback: ->
     @subscriptions = new CompositeDisposable
     @classList.add('popover-list', 'select-list', 'autocomplete-suggestion-list')
-    @subscriptions.add(atom.config.observe('autocomplete-plus.maxSuggestions', => @maxItems = atom.config.get('autocomplete-plus.maxSuggestions')))
     @registerMouseHandling()
 
   attachedCallback: ->
@@ -98,7 +97,7 @@ class SuggestionListElement extends HTMLElement
     @ol.className = 'list-group'
 
   calculateMaxListHeight: ->
-    maxItems = atom.config.get('autocomplete-plus.maxVisibleSuggestions')
+    maxItems = atom.config.get('autocomplete-plus.maxSuggestions')
     li = document.createElement('li')
     li.textContent = 'test'
     @ol.appendChild(li)

--- a/lib/suggestion-list-element.coffee
+++ b/lib/suggestion-list-element.coffee
@@ -97,13 +97,12 @@ class SuggestionListElement extends HTMLElement
     @ol.className = 'list-group'
 
   calculateMaxListHeight: ->
-    maxItems = atom.config.get('autocomplete-plus.maxVisibleSuggestions')
+    maxVisibleItems = atom.config.get('autocomplete-plus.maxVisibleSuggestions')
     li = document.createElement('li')
     li.textContent = 'test'
     @ol.appendChild(li)
     itemHeight = li.offsetHeight
-    console.log maxItems, itemHeight
-    @ol.style['max-height'] = "#{maxItems * itemHeight}px"
+    @ol.style['max-height'] = "#{maxVisibleItems * itemHeight}px"
     li.remove()
 
   renderItems: ->

--- a/lib/suggestion-list-element.coffee
+++ b/lib/suggestion-list-element.coffee
@@ -97,7 +97,7 @@ class SuggestionListElement extends HTMLElement
     @ol.className = 'list-group'
 
   calculateMaxListHeight: ->
-    maxItems = atom.config.get('autocomplete-plus.maxSuggestions')
+    maxItems = atom.config.get('autocomplete-plus.maxVisibleSuggestions')
     li = document.createElement('li')
     li.textContent = 'test'
     @ol.appendChild(li)

--- a/lib/suggestion-list-element.coffee
+++ b/lib/suggestion-list-element.coffee
@@ -15,6 +15,7 @@ class SuggestionListElement extends HTMLElement
     @parentElement.classList.add('autocomplete-plus')
     @addActiveClassToEditor()
     @renderList() unless @ol
+    @calculateMaxListHeight()
     @itemsChanged()
 
   detachedCallback: ->
@@ -95,6 +96,16 @@ class SuggestionListElement extends HTMLElement
     @ol = document.createElement('ol')
     @appendChild(@ol)
     @ol.className = 'list-group'
+
+  calculateMaxListHeight: ->
+    maxItems = atom.config.get('autocomplete-plus.maxVisibleSuggestions')
+    li = document.createElement('li')
+    li.textContent = 'test'
+    @ol.appendChild(li)
+    itemHeight = li.offsetHeight
+    console.log maxItems, itemHeight
+    @ol.style['max-height'] = "#{maxItems * itemHeight}px"
+    li.remove()
 
   renderItems: ->
     items = @visibleItems() or []

--- a/spec/autocomplete-manager-integration-spec.coffee
+++ b/spec/autocomplete-manager-integration-spec.coffee
@@ -19,7 +19,7 @@ describe 'Autocomplete Manager', ->
       workspaceElement = atom.views.getView(atom.workspace)
       jasmine.attachToDOM(workspaceElement)
 
-      atom.config.set('autocomplete-plus.maxSuggestions', 10)
+      atom.config.set('autocomplete-plus.maxVisibleSuggestions', 10)
 
   describe "when an external provider is registered", ->
     class SpecialProvider
@@ -42,11 +42,11 @@ describe 'Autocomplete Manager', ->
       runs ->
         mainModule.consumeProvider(provider: new SpecialProvider)
 
-    describe "when number of suggestions > maxSuggestions", ->
+    describe "when number of suggestions > maxVisibleSuggestions", ->
       beforeEach ->
-        atom.config.set('autocomplete-plus.maxSuggestions', 2)
+        atom.config.set('autocomplete-plus.maxVisibleSuggestions', 2)
 
-      it "only shows the maxSuggestions in the suggestion popup", ->
+      it "only shows the maxVisibleSuggestions in the suggestion popup", ->
         triggerAutocompletion(editor, true, 'a')
 
         runs ->

--- a/spec/autocomplete-manager-integration-spec.coffee
+++ b/spec/autocomplete-manager-integration-spec.coffee
@@ -20,7 +20,6 @@ describe 'Autocomplete Manager', ->
       jasmine.attachToDOM(workspaceElement)
 
       atom.config.set('autocomplete-plus.maxSuggestions', 10)
-      atom.config.set('autocomplete-plus.maxVisibleSuggestions', 10)
 
   describe "when an external provider is registered", ->
     class SpecialProvider
@@ -43,12 +42,11 @@ describe 'Autocomplete Manager', ->
       runs ->
         mainModule.consumeProvider(provider: new SpecialProvider)
 
-    describe "when maxSuggestions > maxVisibleSuggestions", ->
+    describe "when number of suggestions > maxSuggestions", ->
       beforeEach ->
-        atom.config.set('autocomplete-plus.maxSuggestions', 100)
-        atom.config.set('autocomplete-plus.maxVisibleSuggestions', 2)
+        atom.config.set('autocomplete-plus.maxSuggestions', 2)
 
-      it "only shows the maxVisibleSuggestions in the suggestion popup", ->
+      it "only shows the maxSuggestions in the suggestion popup", ->
         triggerAutocompletion(editor, true, 'a')
 
         runs ->

--- a/spec/language-css-spec.coffee
+++ b/spec/language-css-spec.coffee
@@ -8,7 +8,6 @@ describe 'CSS Language Support', ->
       # Set to live completion
       atom.config.set('autocomplete-plus.enableAutoActivation', true)
       atom.config.set('editor.fontSize', '16')
-      atom.config.set('autocomplete-plus.maxSuggestions', 10)
 
       # Set the completion delay
       completionDelay = 100
@@ -53,7 +52,7 @@ describe 'CSS Language Support', ->
         suggestionListView = atom.views.getView(autocompleteManager.suggestionList)
         items = suggestionListView.querySelectorAll('li')
         expect(editorView.querySelector('.autocomplete-plus')).toExist()
-        expect(items.length).toBe(10)
+        expect(items.length).toBe(23)
         expect(items[0]).toHaveText('outline')
         expect(items[1]).toHaveText('outline-color')
         expect(items[2]).toHaveText('outline-width')

--- a/spec/language-css-spec.coffee
+++ b/spec/language-css-spec.coffee
@@ -8,6 +8,7 @@ describe 'CSS Language Support', ->
       # Set to live completion
       atom.config.set('autocomplete-plus.enableAutoActivation', true)
       atom.config.set('editor.fontSize', '16')
+      atom.config.set('autocomplete-plus.maxSuggestions', 10)
 
       # Set the completion delay
       completionDelay = 100

--- a/styles/autocomplete.less
+++ b/styles/autocomplete.less
@@ -13,7 +13,6 @@ autocomplete-suggestion-list.select-list.popover-list {
   }
 
   ol.list-group {
-    max-height: 50vh;
     overflow-y: auto;
     margin-top: 0;
 


### PR DESCRIPTION
This allows the user to set the max number of visible suggestions, and will set the height of the suggestion box accordingly. This provides consistency across multiple editor sizes.

I've also raised the max suggestions to 200. Some providers may return many more than the visible when there is no prefix. For example ternjs:

![](https://camo.githubusercontent.com/f1b70c8d339fb338498b4330103dadf6cda9a5b6/687474703a2f2f7777772e746f626961732d73636875626572742e636f6d2f6769746875622f6769746875622d61746f6d2d7465726e6a732d342e706e67)