### PR TITLE
More correct use of theme colors

### DIFF
--- a/styles/autocomplete.less
+++ b/styles/autocomplete.less
@@ -28,10 +28,13 @@ autocomplete-suggestion-list.select-list.popover-list {
       }
       .character-match {
         font-weight: bold;
-        color: @text-color-selected;
+        color: @text-color-highlight;
+      }
+      &.selected .character-match {
+        color:@text-color-selected;
       }
       &.selected .completion-label {
-        color: @text-color;
+        color: fadeout(@text-color-selected, 60%);
       }
       .completion-label {
         float: right;


### PR DESCRIPTION
This is a continued modification of the colors to allow for all variants of highlight and selected colors set by the theme.

Here's sample colors in One Dark, Atom Light, One Light, and Unity.

![screen shot 2015-02-23 at 11 34 52 am](https://cloud.githubusercontent.com/assets/1680/6331960/7d0878b0-bb50-11e4-887f-b72ca5659de6.png)
![screen shot 2015-02-23 at 11 35 16 am](https://cloud.githubusercontent.com/assets/1680/6331961/7d0f73c2-bb50-11e4-82cd-02d0681f6846.png)
![screen shot 2015-02-23 at 11 35 26 am](https://cloud.githubusercontent.com/assets/1680/6331963/7d1ef2fc-bb50-11e4-8f9c-a6dd6747522f.png)
![screen shot 2015-02-23 at 11 35 38 am](https://cloud.githubusercontent.com/assets/1680/6331962/7d1192c4-bb50-11e4-850c-0ccb7858e9eb.png)
