### PR TITLE
Defer requires

### DIFF
--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -1,10 +1,12 @@
 {Range, TextEditor, CompositeDisposable, Disposable}  = require('atom')
 _ = require('underscore-plus')
-minimatch = require('minimatch')
 path = require('path')
 ProviderManager = require('./provider-manager')
 SuggestionList = require('./suggestion-list')
 SuggestionListElement = require('./suggestion-list-element')
+
+# Deferred requires
+minimatch = null
 
 module.exports =
 class AutocompleteManager
@@ -219,7 +221,9 @@ class AutocompleteManager
   # Returns {Boolean} that defines whether the current file is blacklisted
   isCurrentFileBlackListed: =>
     blacklist = atom.config.get('autocomplete-plus.fileBlacklist')?.map((s) -> s.trim())
-    return false unless blacklist? and blacklist.length
+    return false unless blacklist?.length > 0
+
+    minimatch ?= require('minimatch')
     fileName = path.basename(@buffer.getPath())
     for blacklistGlob in blacklist
       return true if minimatch(fileName, blacklistGlob)

--- a/lib/provider-manager.coffee
+++ b/lib/provider-manager.coffee
@@ -2,8 +2,10 @@
 ScopedPropertyStore = require('scoped-property-store')
 _ = require('underscore-plus')
 Uuid = require('node-uuid')
-SymbolProvider = require('./symbol-provider')
-FuzzyProvider = require('./fuzzy-provider')
+
+# Deferred requires
+SymbolProvider = null
+FuzzyProvider =  null
 
 module.exports =
 class ProviderManager
@@ -60,8 +62,10 @@ class ProviderManager
     if enabled
       return if @fuzzyProvider? or @fuzzyRegistration?
       if atom.config.get('autocomplete-plus.defaultProvider') is 'Symbol'
+        SymbolProvider ?= require('./symbol-provider')
         @fuzzyProvider = new SymbolProvider()
       else
+        FuzzyProvider ?= require('./fuzzy-provider')
         @fuzzyProvider = new FuzzyProvider()
       @fuzzyRegistration = @registerProvider(@fuzzyProvider)
     else

--- a/lib/provider-manager.coffee
+++ b/lib/provider-manager.coffee
@@ -1,4 +1,4 @@
-{CompositeDisposable, Disposable, Emitter} = require('atom')
+{CompositeDisposable, Disposable} = require('atom')
 ScopedPropertyStore = require('scoped-property-store')
 _ = require('underscore-plus')
 Uuid = require('node-uuid')

--- a/package.json
+++ b/package.json
@@ -14,13 +14,13 @@
     "minimatch": ">=0.2.14",
     "node-uuid": ">=1.4.1",
     "scoped-property-store": ">=0.16.2",
-    "temp": ">=0.7.0",
     "selector-kit": "^0.1",
     "underscore-plus": ">=1.0.0"
   },
   "devDependencies": {
     "coffeelint": ">=1.8.1",
-    "fs-plus": ">=2.4.0"
+    "fs-plus": ">=2.4.0",
+    "temp": ">=0.7.0"
   },
   "consumedServices": {
     "autocomplete.provider": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "dependencies": {
     "async": ">=0.9.0",
     "fuzzaldrin": ">=1.0.0",
-    "grim": ">=0.12.0",
     "minimatch": ">=0.2.14",
     "node-uuid": ">=1.4.1",
     "scoped-property-store": ">=0.16.2",


### PR DESCRIPTION
* Defer minimatch require so it is only loaded when a blacklist exists
* Only require the active symbol provider instead of both
* Move `temp` to a dev dependency
* Remove unused `grim` dependency