### PR TITLE
If vim-mode is active, activate autocomplete only in insert mode

### DIFF
--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -268,7 +268,14 @@ class AutocompleteManager
     return if @disposed
     return @hideSuggestionList() if @compositionInProgress
     autoActivationEnabled = atom.config.get('autocomplete-plus.enableAutoActivation')
-    wouldAutoActivate = newText.trim().length is 1 or ((@backspaceTriggersAutocomplete or @suggestionList.isActive()) and oldText.trim().length is 1)
+    editorElement = atom.views.getView(atom.workspace.getActiveTextEditor())
+    vimModeActive = editorElement?.classList?.contains('vim-mode')
+
+    if vimModeActive
+      vimInsertModeActive = editorElement?.classList?.contains('insert-mode')
+
+    wouldAutoActivate = (!vimModeActive or vimInsertModeActive) and
+    (newText.trim().length is 1 or ((@backspaceTriggersAutocomplete or @suggestionList.isActive()) and oldText.trim().length is 1))
 
     if autoActivationEnabled and wouldAutoActivate
       @cancelHideSuggestionListRequest()


### PR DESCRIPTION
This patch prevents autocomplete from triggering when in vim-mode "command" (normal) mode (e.g. when pressing `x`).