### PR TITLE
Quick fix for #298

### DIFF
--- a/lib/suggestion-list-element.coffee
+++ b/lib/suggestion-list-element.coffee
@@ -139,7 +139,10 @@ class SuggestionListElement extends HTMLElement
         while wordIndex < replacement.length and replacement[wordIndex].toLowerCase() isnt ch.toLowerCase()
           wordIndex += 1
         preChar = replacement.substring(lastWordIndex, wordIndex)
-        highlightedChar = "<span class=\"character-match\">#{replacement[wordIndex]}</span>"
+        highlightedChar = if replacement[wordIndex]?
+          "<span class=\"character-match\">#{replacement[wordIndex]}</span>"
+        else
+          ""
         displayHtml = "#{displayHtml}#{preChar}#{highlightedChar}"
         wordIndex += 1
         lastWordIndex = wordIndex


### PR DESCRIPTION
It is entirely possible that prefix is not contained in suggested completion. If that is the case, #298 happens. This PR fixes that.