### PR TITLE
Only migrate config when it exists

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -104,7 +104,7 @@ module.exports =
   activate: ->
     # Upgrade to the new config key name
     oldMax = atom.config.get('autocomplete-plus.maxSuggestions')
-    if oldMax isnt 10
+    if oldMax? and oldMax isnt 10
       atom.config.transact ->
         atom.config.set('autocomplete-plus.maxVisibleSuggestions', oldMax)
         atom.config.unset('autocomplete-plus.maxSuggestions')


### PR DESCRIPTION
I noticed my config was getting saved each time Atom started up and traced it to this check.

If people installed `autocomplete-plus` after this config was migrated (I did), then `oldMax` would be null and the migration would occur each time the package was activated.

/cc @benogle looks like this changed in https://github.com/atom-community/autocomplete-plus/pull/272