### PR TITLE
Allow Auto Activation When Bracket Matcher Automatically Inserts A Match

### DIFF
--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -363,7 +363,7 @@ class AutocompleteManager
     return if @disposed
     return @hideSuggestionList() if @compositionInProgress
     autoActivationEnabled = atom.config.get('autocomplete-plus.enableAutoActivation')
-    wouldAutoActivate = newText.trim().length is 1 or ((@backspaceTriggersAutocomplete or @suggestionList.isActive()) and oldText.trim().length is 1)
+    wouldAutoActivate = newText.trim().length in [1..2] or ((@backspaceTriggersAutocomplete or @suggestionList.isActive()) and oldText.trim().length in [1..2])
 
     if autoActivationEnabled and wouldAutoActivate
       @cancelHideSuggestionListRequest()


### PR DESCRIPTION
This takes part of #294 and separates it out for immediate merge. This allows providers to get a suggestion request if someone types `(`, `[`, etc. and bracket matcher inserts the corresponding `)`, `]`, etc.