### PR TITLE
Remove the scoped property store

### DIFF
--- a/lib/fuzzy-provider.coffee
+++ b/lib/fuzzy-provider.coffee
@@ -11,6 +11,7 @@ class FuzzyProvider
 
   selector: '*'
   inclusionPriority: 0
+  suggestionPriority: 0
   id: 'autocomplete-plus-fuzzyprovider'
 
   constructor: ->

--- a/lib/provider-manager.coffee
+++ b/lib/provider-manager.coffee
@@ -37,7 +37,7 @@ class ProviderMetadata
     if providerBlacklist = @provider.providerblacklist?['autocomplete-plus-fuzzyprovider']
       @disableDefaultProviderSelectors = Selector.create(providerBlacklist)
 
-  matchesScopeDescriptor: (scopeChain) ->
+  matchesScopeChain: (scopeChain) ->
     if @disableForSelectors?
       return false if selectorsMatchScopeChain(@disableForSelectors, scopeChain)
 
@@ -89,7 +89,7 @@ class ProviderManager
 
     for providerMetadata in @providers
       {provider} = providerMetadata
-      if providerMetadata.matchesScopeDescriptor(scopeChain)
+      if providerMetadata.matchesScopeChain(scopeChain)
         matchingProviders.push(provider)
         disableDefaultProvider = true if providerMetadata.shouldDisableDefaultProvider(scopeChain)
 

--- a/lib/provider-manager.coffee
+++ b/lib/provider-manager.coffee
@@ -4,11 +4,12 @@ semver = require 'semver'
 {Selector} = require 'selector-kit'
 stableSort = require 'stable'
 
+{selectorsMatchScopeChain} = require('./scope-helpers')
+
 # Deferred requires
 SymbolProvider = null
 FuzzyProvider =  null
 grim = null
-selectorsMatchScopeChain = null
 ProviderMetadata = null
 
 module.exports =
@@ -33,8 +34,6 @@ class ProviderManager
     @providers = null
 
   providersForScopeDescriptor: (scopeDescriptor) =>
-    selectorsMatchScopeChain ?= require('./scope-helpers').selectorsMatchScopeChain
-
     scopeChain = scopeDescriptor?.getScopeChain?() or scopeDescriptor
     return [] unless scopeChain
     return [] if @globalBlacklistSelectors? and selectorsMatchScopeChain(@globalBlacklistSelectors, scopeChain)

--- a/lib/provider-manager.coffee
+++ b/lib/provider-manager.coffee
@@ -53,17 +53,8 @@ class ProviderManager
           disableDefaultProvider = true
 
     matchingProviders = _.without(matchingProviders, @fuzzyProvider) if disableDefaultProvider
-    matchingProviders = stableSort matchingProviders, (providerA, providerB) =>
-      specificityA = @metadataForProvider(providerA).getSpecificity(scopeChain)
-      specificityB = @metadataForProvider(providerB).getSpecificity(scopeChain)
-      difference = specificityB - specificityA
-
-      if difference isnt 0
-        difference
-      else
-        (providerB.suggestionPriority ? 1) - (providerA.suggestionPriority ? 1)
-
-    (provider for provider in matchingProviders when (provider.inclusionPriority ? 0) >= lowestIncludedPriority)
+    matchingProviders = (provider for provider in matchingProviders when (provider.inclusionPriority ? 0) >= lowestIncludedPriority)
+    stableSort(matchingProviders, ProviderComparator)
 
   toggleFuzzyProvider: (enabled) =>
     return unless enabled?
@@ -170,3 +161,10 @@ class ProviderManager
         disposable.dispose()
 
     disposable
+
+ProviderComparator = (providerA, providerB) ->
+  specificityA = @metadataForProvider(providerA).getSpecificity(scopeChain)
+  specificityB = @metadataForProvider(providerB).getSpecificity(scopeChain)
+  difference = specificityB - specificityA
+  difference = (providerB.suggestionPriority ? 1) - (providerA.suggestionPriority ? 1) if difference is 0
+  difference

--- a/lib/provider-manager.coffee
+++ b/lib/provider-manager.coffee
@@ -6,7 +6,6 @@ semver = require 'semver'
 stableSort = require 'stable'
 
 slick = require 'atom-slick'
-window.Selector = Selector
 
 # Deferred requires
 SymbolProvider = null

--- a/lib/provider-manager.coffee
+++ b/lib/provider-manager.coffee
@@ -2,6 +2,7 @@
 ScopedPropertyStore = require 'scoped-property-store'
 _ = require 'underscore-plus'
 semver = require 'semver'
+{specificity} = require 'clear-cut'
 
 # Deferred requires
 SymbolProvider = null
@@ -55,7 +56,7 @@ class ProviderManager
     fuzzyProviderBlacklisted = _.chain(providers).filter((p) -> p.value.providerblacklisted? and p.value.providerblacklisted is 'autocomplete-plus-fuzzyprovider').map((p) -> p.value.provider).value() if @fuzzyProvider?
 
     providers = _.chain(providers)
-      .sortBy((p) -> -p.scopeSelector.length) # Sort by a bad proxy for 'specificity'
+      .sortBy((p) -> -specificity(p.scopeSelector))
       .map((p) -> p.value.provider)
       .uniq()
       .difference(blacklistedProviders) # Exclude Blacklisted Providers

--- a/lib/provider-manager.coffee
+++ b/lib/provider-manager.coffee
@@ -54,7 +54,12 @@ class ProviderManager
 
     matchingProviders = _.without(matchingProviders, @fuzzyProvider) if disableDefaultProvider
     matchingProviders = (provider for provider in matchingProviders when (provider.inclusionPriority ? 0) >= lowestIncludedPriority)
-    stableSort(matchingProviders, ProviderComparator)
+    stableSort matchingProviders, (providerA, providerB) =>
+      specificityA = @metadataForProvider(providerA).getSpecificity(scopeChain)
+      specificityB = @metadataForProvider(providerB).getSpecificity(scopeChain)
+      difference = specificityB - specificityA
+      difference = (providerB.suggestionPriority ? 1) - (providerA.suggestionPriority ? 1) if difference is 0
+      difference
 
   toggleFuzzyProvider: (enabled) =>
     return unless enabled?
@@ -161,10 +166,3 @@ class ProviderManager
         disposable.dispose()
 
     disposable
-
-ProviderComparator = (providerA, providerB) ->
-  specificityA = @metadataForProvider(providerA).getSpecificity(scopeChain)
-  specificityB = @metadataForProvider(providerB).getSpecificity(scopeChain)
-  difference = specificityB - specificityA
-  difference = (providerB.suggestionPriority ? 1) - (providerA.suggestionPriority ? 1) if difference is 0
-  difference

--- a/lib/provider-manager.coffee
+++ b/lib/provider-manager.coffee
@@ -109,6 +109,7 @@ class ProviderManager
     @subscriptions.add(provider) if provider.dispose?
 
   removeProvider: (provider) =>
+    return unless @providers
     for providerMetadata, i in @providers
       if providerMetadata.provider is provider
         @providers.splice(i, 1)

--- a/lib/provider-manager.coffee
+++ b/lib/provider-manager.coffee
@@ -86,12 +86,16 @@ class ProviderManager
 
     matchingProviders = []
     disableDefaultProvider = false
+    lowestIncludedPriority = 0
 
     for providerMetadata in @providers
       {provider} = providerMetadata
       if providerMetadata.matchesScopeChain(scopeChain)
         matchingProviders.push(provider)
-        disableDefaultProvider = true if providerMetadata.shouldDisableDefaultProvider(scopeChain)
+        if provider.excludeLowerPriority?
+          lowestIncludedPriority = Math.max(lowestIncludedPriority, provider.inclusionPriority ? 0)
+        if providerMetadata.shouldDisableDefaultProvider(scopeChain)
+          disableDefaultProvider = true
 
     matchingProviders = _.without(matchingProviders, @fuzzyProvider) if disableDefaultProvider
 
@@ -105,10 +109,6 @@ class ProviderManager
       else
         (providerB.suggestionPriority ? 1) - (providerA.suggestionPriority ? 1)
 
-    lowestIncludedPriority = 0
-    for provider in matchingProviders
-      if provider.excludeLowerPriority?
-        lowestIncludedPriority = Math.max(lowestIncludedPriority, provider.inclusionPriority ? 0)
     (provider for provider in matchingProviders when (provider.inclusionPriority ? 0) >= lowestIncludedPriority)
 
   toggleFuzzyProvider: (enabled) =>

--- a/lib/provider-metadata.coffee
+++ b/lib/provider-metadata.coffee
@@ -1,0 +1,34 @@
+{specificity} = require 'clear-cut'
+{Selector} = require 'selector-kit'
+{selectorForScopeChain, selectorsMatchScopeChain} = require './scope-helpers'
+
+module.exports =
+class ProviderMetadata
+  constructor: (@provider, @apiVersion) ->
+    @selectors = Selector.create(@provider.selector)
+    @disableForSelectors = Selector.create(@provider.disableForSelector) if @provider.disableForSelector?
+
+    # TODO API: remove this when 1.0 is pulled out
+    if providerBlacklist = @provider.providerblacklist?['autocomplete-plus-fuzzyprovider']
+      @disableDefaultProviderSelectors = Selector.create(providerBlacklist)
+
+  matchesScopeChain: (scopeChain) ->
+    if @disableForSelectors?
+      return false if selectorsMatchScopeChain(@disableForSelectors, scopeChain)
+
+    if selectorsMatchScopeChain(@selectors, scopeChain)
+      true
+    else
+      false
+
+  shouldDisableDefaultProvider: (scopeChain) ->
+    if @disableDefaultProviderSelectors?
+      selectorsMatchScopeChain(@disableDefaultProviderSelectors, scopeChain)
+    else
+      false
+
+  getSpecificity: (scopeChain) ->
+    if selector = selectorForScopeChain(@selectors, scopeChain)
+      selector.getSpecificity()
+    else
+      0

--- a/lib/scope-helpers.coffee
+++ b/lib/scope-helpers.coffee
@@ -1,0 +1,20 @@
+slick = require 'atom-slick'
+
+EscapeCharacterRegex = /[-!"#$%&'*+,/:;=?@|^~()<>{}[\]]/g
+
+parseScopeChain = (scopeChain) ->
+  scopeChain = scopeChain.replace EscapeCharacterRegex, (match) -> "\\#{match[0]}"
+  scope for scope in slick.parse(scopeChain)[0] ? []
+
+selectorForScopeChain = (selectors, scopeChain) ->
+  scopes = parseScopeChain(scopeChain)
+  for selector in selectors
+    while scopes.length > 0
+      return selector if selector.matches(scopes)
+      scopes.pop()
+  null
+
+selectorsMatchScopeChain = (selectors, scopeChain) ->
+  selectorForScopeChain(selectors, scopeChain)?
+
+module.exports = {parseScopeChain, selectorsMatchScopeChain, selectorForScopeChain}

--- a/lib/scope-helpers.coffee
+++ b/lib/scope-helpers.coffee
@@ -7,8 +7,8 @@ parseScopeChain = (scopeChain) ->
   scope for scope in slick.parse(scopeChain)[0] ? []
 
 selectorForScopeChain = (selectors, scopeChain) ->
-  scopes = parseScopeChain(scopeChain)
   for selector in selectors
+    scopes = parseScopeChain(scopeChain)
     while scopes.length > 0
       return selector if selector.matches(scopes)
       scopes.pop()

--- a/lib/symbol-provider.coffee
+++ b/lib/symbol-provider.coffee
@@ -15,6 +15,7 @@ class SymbolProvider
 
   selector: '*'
   inclusionPriority: 0
+  suggestionPriority: 0
 
   config: null
   defaultConfig:

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "atom": ">=0.183.0 <2.0.0"
   },
   "dependencies": {
+    "clear-cut": "^0.4.0",
     "fuzzaldrin": "^2.1.0",
     "grim": "^1.2.0",
     "minimatch": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "fuzzaldrin": "^2.1.0",
     "grim": "^1.2.0",
     "minimatch": "^2.0.1",
-    "scoped-property-store": "^0.16.2",
     "selector-kit": "^0.1",
     "semver": "^4.3.1",
     "stable": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "atom": ">=0.183.0 <2.0.0"
   },
   "dependencies": {
+    "atom-slick": "^2.0.0",
     "clear-cut": "^0.4.0",
     "fuzzaldrin": "^2.1.0",
     "grim": "^1.2.0",
@@ -15,6 +16,7 @@
     "scoped-property-store": "^0.16.2",
     "selector-kit": "^0.1",
     "semver": "^4.3.1",
+    "stable": "^0.1.5",
     "underscore-plus": "^1.6.6"
   },
   "devDependencies": {

--- a/spec/provider-manager-spec.coffee
+++ b/spec/provider-manager-spec.coffee
@@ -31,14 +31,12 @@ describe 'Provider Manager', ->
     it 'is constructed correctly', ->
       expect(providerManager.providers).toBeDefined()
       expect(providerManager.subscriptions).toBeDefined()
-      expect(providerManager.store).toBeDefined()
       expect(providerManager.fuzzyProvider).toBeDefined()
 
     it 'disposes correctly', ->
       providerManager.dispose()
       expect(providerManager.providers).toBeNull()
       expect(providerManager.subscriptions).toBeNull()
-      expect(providerManager.store).toBeNull()
       expect(providerManager.fuzzyProvider).toBeNull()
 
     it 'registers FuzzyProvider for all scopes', ->
@@ -56,17 +54,15 @@ describe 'Provider Manager', ->
       expect(_.contains(providerManager.subscriptions?.disposables, testProvider)).toEqual(true)
 
     it 'removes providers', ->
-      expect(providerManager.providers.has(testProvider)).toEqual(false)
+      expect(providerManager.metadataForProvider(testProvider)).toBeFalsy()
       expect(_.contains(providerManager.subscriptions?.disposables, testProvider)).toEqual(false)
 
       providerManager.addProvider(testProvider)
-      expect(providerManager.providers.has(testProvider)).toEqual(true)
-      expect(providerManager.providers.get(testProvider)).toBeDefined()
-      expect(providerManager.providers.get(testProvider)).not.toEqual('')
+      expect(providerManager.metadataForProvider(testProvider)).toBeTruthy()
       expect(_.contains(providerManager.subscriptions?.disposables, testProvider)).toEqual(true)
 
       providerManager.removeProvider(testProvider)
-      expect(providerManager.providers.has(testProvider)).toEqual(false)
+      expect(providerManager.metadataForProvider(testProvider)).toBeFalsy()
       expect(_.contains(providerManager.subscriptions?.disposables, testProvider)).toEqual(false)
 
     it 'can identify a provider with a missing getSuggestions', ->
@@ -127,47 +123,47 @@ describe 'Provider Manager', ->
     it 'registers a valid provider', ->
       expect(_.size(providerManager.providersForScopeDescriptor('.source.js'))).toEqual(1)
       expect(_.contains(providerManager.providersForScopeDescriptor('.source.js'), testProvider)).toEqual(false)
-      expect(providerManager.providers.has(testProvider)).toEqual(false)
+      expect(providerManager.metadataForProvider(testProvider)).toBeFalsy()
 
       registration = providerManager.registerProvider(testProvider)
       expect(_.size(providerManager.providersForScopeDescriptor('.source.js'))).toEqual(2)
       expect(_.contains(providerManager.providersForScopeDescriptor('.source.js'), testProvider)).toEqual(true)
-      expect(providerManager.providers.has(testProvider)).toEqual(true)
+      expect(providerManager.metadataForProvider(testProvider)).toBeTruthy()
 
     it 'removes a registration', ->
       expect(_.size(providerManager.providersForScopeDescriptor('.source.js'))).toEqual(1)
       expect(_.contains(providerManager.providersForScopeDescriptor('.source.js'), testProvider)).toEqual(false)
-      expect(providerManager.providers.has(testProvider)).toEqual(false)
+      expect(providerManager.metadataForProvider(testProvider)).toBeFalsy()
 
       registration = providerManager.registerProvider(testProvider)
       expect(_.size(providerManager.providersForScopeDescriptor('.source.js'))).toEqual(2)
       expect(_.contains(providerManager.providersForScopeDescriptor('.source.js'), testProvider)).toEqual(true)
-      expect(providerManager.providers.has(testProvider)).toEqual(true)
+      expect(providerManager.metadataForProvider(testProvider)).toBeTruthy()
       registration.dispose()
 
       expect(_.size(providerManager.providersForScopeDescriptor('.source.js'))).toEqual(1)
       expect(_.contains(providerManager.providersForScopeDescriptor('.source.js'), testProvider)).toEqual(false)
-      expect(providerManager.providers.has(testProvider)).toEqual(false)
+      expect(providerManager.metadataForProvider(testProvider)).toBeFalsy()
 
     it 'does not create duplicate registrations for the same scope', ->
       expect(_.size(providerManager.providersForScopeDescriptor('.source.js'))).toEqual(1)
       expect(_.contains(providerManager.providersForScopeDescriptor('.source.js'), testProvider)).toEqual(false)
-      expect(providerManager.providers.has(testProvider)).toEqual(false)
+      expect(providerManager.metadataForProvider(testProvider)).toBeFalsy()
 
       registration = providerManager.registerProvider(testProvider)
       expect(_.size(providerManager.providersForScopeDescriptor('.source.js'))).toEqual(2)
       expect(_.contains(providerManager.providersForScopeDescriptor('.source.js'), testProvider)).toEqual(true)
-      expect(providerManager.providers.has(testProvider)).toEqual(true)
+      expect(providerManager.metadataForProvider(testProvider)).toBeTruthy()
 
       registration = providerManager.registerProvider(testProvider)
       expect(_.size(providerManager.providersForScopeDescriptor('.source.js'))).toEqual(2)
       expect(_.contains(providerManager.providersForScopeDescriptor('.source.js'), testProvider)).toEqual(true)
-      expect(providerManager.providers.has(testProvider)).toEqual(true)
+      expect(providerManager.metadataForProvider(testProvider)).toBeTruthy()
 
       registration = providerManager.registerProvider(testProvider)
       expect(_.size(providerManager.providersForScopeDescriptor('.source.js'))).toEqual(2)
       expect(_.contains(providerManager.providersForScopeDescriptor('.source.js'), testProvider)).toEqual(true)
-      expect(providerManager.providers.has(testProvider)).toEqual(true)
+      expect(providerManager.metadataForProvider(testProvider)).toBeTruthy()
 
     it 'does not register an invalid provider', ->
       bogusProvider =
@@ -178,12 +174,12 @@ describe 'Provider Manager', ->
 
       expect(_.size(providerManager.providersForScopeDescriptor('.source.js'))).toEqual(1)
       expect(_.contains(providerManager.providersForScopeDescriptor('.source.js'), bogusProvider)).toEqual(false)
-      expect(providerManager.providers.has(bogusProvider)).toEqual(false)
+      expect(providerManager.metadataForProvider(bogusProvider)).toBeFalsy()
 
       registration = providerManager.registerProvider(bogusProvider)
       expect(_.size(providerManager.providersForScopeDescriptor('.source.js'))).toEqual(1)
       expect(_.contains(providerManager.providersForScopeDescriptor('.source.js'), bogusProvider)).toEqual(false)
-      expect(providerManager.providers.has(bogusProvider)).toEqual(false)
+      expect(providerManager.metadataForProvider(bogusProvider)).toBeFalsy()
 
     it 'registers a provider with a blacklist', ->
       testProvider =
@@ -201,12 +197,12 @@ describe 'Provider Manager', ->
 
       expect(_.size(providerManager.providersForScopeDescriptor('.source.js'))).toEqual(1)
       expect(_.contains(providerManager.providersForScopeDescriptor('.source.js'), testProvider)).toEqual(false)
-      expect(providerManager.providers.has(testProvider)).toEqual(false)
+      expect(providerManager.metadataForProvider(testProvider)).toBeFalsy()
 
       registration = providerManager.registerProvider(testProvider)
       expect(_.size(providerManager.providersForScopeDescriptor('.source.js'))).toEqual(2)
       expect(_.contains(providerManager.providersForScopeDescriptor('.source.js'), testProvider)).toEqual(true)
-      expect(providerManager.providers.has(testProvider)).toEqual(true)
+      expect(providerManager.metadataForProvider(testProvider)).toBeTruthy()
 
   describe 'when no providers have been registered, and enableBuiltinProvider is false', ->
 
@@ -401,8 +397,8 @@ describe 'Provider Manager', ->
     it 'exclude the lower priority provider, the default, when one with a higher proirity excludes the lower', ->
       providers = providerManager.providersForScopeDescriptor('.source.js')
       expect(providers).toHaveLength 3
-      expect(providers[0]).toEqual mainProvider
-      expect(providers[1]).toEqual accessoryProvider2
+      expect(providers[0]).toEqual accessoryProvider2
+      expect(providers[1]).toEqual mainProvider
       expect(providers[2]).toEqual accessoryProvider1
 
     it 'excludes the all lower priority providers when multiple providers of lower priority', ->


### PR DESCRIPTION
Use of the scoped property store was complex and confusing. This PR takes a much more straightforward approach to storing and filtering the providers. 

Other things improved:

* Specificity sorting uses real specificity
* Sorting of providers is stable, so providers added later will come later when specificities are equal.