### PR TITLE
Fix issues when suggestionListFollows is `Word`

### DIFF
--- a/lib/suggestion-list.coffee
+++ b/lib/suggestion-list.coffee
@@ -65,7 +65,6 @@ class SuggestionList
     @emitter.on('did-select-previous', fn)
 
   cancel: =>
-    @subscriptions.remove(@marker)
     @emitter.emit('did-cancel')
 
   onDidCancel: (fn) ->
@@ -80,16 +79,15 @@ class SuggestionList
     @destroyOverlay()
 
     if atom.config.get('autocomplete-plus.suggestionListFollows') is 'Cursor'
-      @marker = editor.getLastCursor()?.getMarker()
-      return unless @marker?
+      marker = editor.getLastCursor()?.getMarker()
+      return unless marker?
     else
       cursor = editor.getLastCursor()
       return unless cursor?
       position = cursor.getBeginningOfCurrentWordBufferPosition()
-      @marker = editor.markBufferPosition(position)
-      @subscriptions.add(@marker)
+      marker = @suggestionMarker = editor.markBufferPosition(position)
 
-    @overlayDecoration = editor.decorateMarker(@marker, {type: 'overlay', item: this})
+    @overlayDecoration = editor.decorateMarker(marker, {type: 'overlay', item: this})
     @addKeyboardInteraction()
     @active = true
 
@@ -100,7 +98,11 @@ class SuggestionList
     @active = false
 
   destroyOverlay: =>
-    @overlayDecoration?.destroy()
+    if @suggestionMarker?
+      @suggestionMarker.destroy()
+    else
+      @overlayDecoration?.destroy()
+    @suggestionMarker = undefined
     @overlayDecoration = undefined
 
   changeItems: (@items) ->

--- a/spec/autocomplete-manager-integration-spec.coffee
+++ b/spec/autocomplete-manager-integration-spec.coffee
@@ -231,6 +231,28 @@ describe 'Autocomplete Manager', ->
           atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
           expect(editor.getText()).toBe 'something'
 
+    describe "when autocomplete-plus.suggestionListFollows is 'Word'", ->
+      beforeEach ->
+        atom.config.set('autocomplete-plus.suggestionListFollows', 'Word')
+
+      afterEach ->
+        atom.config.set('autocomplete-plus.suggestionListFollows', 'Cursor')
+
+      it "opens to the correct position, and correctly closes on cancel", ->
+        editor.insertText('x ab')
+        triggerAutocompletion(editor, false, 'c')
+
+        runs ->
+          overlayElement = editorView.querySelector('.autocomplete-plus')
+
+          expect(overlayElement).toExist()
+
+          left = editorView.pixelPositionForBufferPosition([0, 2]).left
+          expect(overlayElement.style.left).toBe "#{left}px"
+
+          atom.commands.dispatch(editorView, 'autocomplete-plus:cancel')
+          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+
   describe 'when opening a file without a path', ->
     beforeEach ->
       waitsForPromise ->


### PR DESCRIPTION
There were some issues when `suggestionListFollows` is `Word`

* The markers created were never destroyed!
* The marker was added to the subscriptions, but it does not have a dispose method. So on deactivate, there was an exception.
* There were no specs