### PR TITLE
Remove auto-snippet-expansion when `isSnippet` is defined

### DIFF
--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -262,13 +262,6 @@ class AutocompleteManager
 
     @replaceTextWithMatch(suggestion)
 
-    # FIXME: move this to the snippet provider's onDidInsertSuggestion() method
-    # when the API has been updated.
-    if suggestion.isSnippet
-      setTimeout =>
-        atom.commands.dispatch(atom.views.getView(@editor), 'snippets:expand')
-      , 1
-
     # TODO API: Remove when we remove the 1.0 API
     if apiIs20
       suggestion.provider.onDidInsertSuggestion?({@editor, suggestion, triggerPosition})


### PR DESCRIPTION
This was only in there for the autocomplete-snippets package, which now expands on its own.