### PR TITLE
Only replace replacementPrefix when it matches text before cursor

### DIFF
--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -308,6 +308,7 @@ class AutocompleteManager
             @snippetsManager.insertSnippet(match.snippet, @editor, cursor)
           else
             selection.insertText(match.text ? match.snippet)
+      return
 
   # Private: Checks whether the current file is blacklisted.
   #


### PR DESCRIPTION
Previously, you could add several cursors, trigger autocomplete, and it would replace prefixes that had the same length, even when the prefixes didnt match. 

cc @nathansobo as this will no longer merge selections.