### PR TITLE
Attempt To Clean Up Bracket Matcher Accommodation

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,15 +3,13 @@ version: "{build}"
 os: Windows Server 2012 R2
 
 install:
-  - appveyor DownloadFile https://atom.io/download/windows -FileName AtomSetup.exe
-  - AtomSetup.exe /silent
+  - choco install atom
 
 build_script:
   - cd %APPVEYOR_BUILD_FOLDER%
-  - SET PATH=%LOCALAPPDATA%\atom\bin;%PATH%
-  - apm clean
-  - apm install
-  - apm test
+  - "%LOCALAPPDATA%\atom\bin\apm clean"
+  - "%LOCALAPPDATA%\atom\bin\apm install"
+  - "%LOCALAPPDATA%\atom\bin\apm test"
 
 test: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,12 +4,13 @@ os: Windows Server 2012 R2
 
 install:
   - choco install atom
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - "%LOCALAPPDATA%/atom/bin/apm clean"
+  - "%LOCALAPPDATA%/atom/bin/apm install"
 
 build_script:
   - cd %APPVEYOR_BUILD_FOLDER%
-  - "%LOCALAPPDATA%\atom\bin\apm clean"
-  - "%LOCALAPPDATA%\atom\bin\apm install"
-  - "%LOCALAPPDATA%\atom\bin\apm test"
+  - "%LOCALAPPDATA%/atom/bin/apm test --path %LOCALAPPDATA%/atom/bin/atom.cmd"
 
 test: off
 

--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -24,7 +24,6 @@ class AutocompleteManager
   editorView: null
   providerManager: null
   ready: false
-  spaceTriggersAutocomplete: false
   subscriptions: null
   suggestionDelay: 50
   suggestionList: null
@@ -96,7 +95,6 @@ class AutocompleteManager
     # Watch config values
     @subscriptions.add(atom.config.observe('autosave.enabled', (value) => @autosaveEnabled = value))
     @subscriptions.add(atom.config.observe('autocomplete-plus.backspaceTriggersAutocomplete', (value) => @backspaceTriggersAutocomplete = value))
-    @subscriptions.add(atom.config.observe('autocomplete-plus.spaceTriggersAutocomplete', (value) => @spaceTriggersAutocomplete = value))
 
     # Handle events from suggestion list
     @subscriptions.add(@suggestionList.onDidConfirm(@confirm))
@@ -360,12 +358,8 @@ class AutocompleteManager
     return @hideSuggestionList() if @compositionInProgress
     autoActivationEnabled = atom.config.get('autocomplete-plus.enableAutoActivation')
     # TODO: Can we avoid bracket-matcher causing a 2-character change in the buffer changed event (can we get each character separately)?
-    wouldAutoActivate = false
-    if @spaceTriggersAutocomplete
-      wouldAutoActivate = (newText.length is 1 or newText in @bracketMatcherPairs) or ((@backspaceTriggersAutocomplete or @suggestionList.isActive()) and (oldText.trim().length is 1 or oldText in @bracketMatcherPairs))
-    else
-      wouldAutoActivate = (newText.trim().length is 1 or newText in @bracketMatcherPairs) or ((@backspaceTriggersAutocomplete or @suggestionList.isActive()) and (oldText.trim().length is 1 or oldText in @bracketMatcherPairs))
-
+    wouldAutoActivate = (newText.length is 1 or newText in @bracketMatcherPairs) or ((@backspaceTriggersAutocomplete or @suggestionList.isActive()) and (oldText.trim().length is 1 or oldText in @bracketMatcherPairs))
+    
     if autoActivationEnabled and wouldAutoActivate
       @cancelHideSuggestionListRequest()
       @requestNewSuggestions()

--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -358,8 +358,8 @@ class AutocompleteManager
     return @hideSuggestionList() if @compositionInProgress
     autoActivationEnabled = atom.config.get('autocomplete-plus.enableAutoActivation')
     # TODO: Can we avoid bracket-matcher causing a 2-character change in the buffer changed event (can we get each character separately)?
-    wouldAutoActivate = (newText.length is 1 or newText in @bracketMatcherPairs) or ((@backspaceTriggersAutocomplete or @suggestionList.isActive()) and (oldText.trim().length is 1 or oldText in @bracketMatcherPairs))
-    
+    wouldAutoActivate = (newText is ' ' or newText.trim().length is 1 or newText in @bracketMatcherPairs) or ((@backspaceTriggersAutocomplete or @suggestionList.isActive()) and (oldText is ' ' or oldText.trim().length is 1 or oldText in @bracketMatcherPairs))
+
     if autoActivationEnabled and wouldAutoActivate
       @cancelHideSuggestionListRequest()
       @requestNewSuggestions()

--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -357,9 +357,15 @@ class AutocompleteManager
     return if @disposed
     return @hideSuggestionList() if @compositionInProgress
     autoActivationEnabled = atom.config.get('autocomplete-plus.enableAutoActivation')
-    # TODO: Can we avoid bracket-matcher causing a 2-character change in the buffer changed event (can we get each character separately)?
-    wouldAutoActivate = (newText is ' ' or newText.trim().length is 1 or newText in @bracketMatcherPairs) or ((@backspaceTriggersAutocomplete or @suggestionList.isActive()) and (oldText is ' ' or oldText.trim().length is 1 or oldText in @bracketMatcherPairs))
-
+    wouldAutoActivate = false
+    if newText?.length
+      # Activate on space, a non-whitespace character, or a bracket-matcher pair
+      wouldAutoActivate = newText is ' ' or newText.trim().length is 1 or newText in @bracketMatcherPairs
+    else if oldText?.length
+      # Suggestion list must be either active or backspaceTriggersAutocomplete must be true for activation to occur
+      # Activate on removal of a space, a non-whitespace character, or a bracket-matcher pair
+      wouldAutoActivate = (@backspaceTriggersAutocomplete or @suggestionList.isActive()) and (oldText is ' ' or oldText.trim().length is 1 or oldText in @bracketMatcherPairs)
+    
     if autoActivationEnabled and wouldAutoActivate
       @cancelHideSuggestionListRequest()
       @requestNewSuggestions()

--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -358,14 +358,16 @@ class AutocompleteManager
     return @hideSuggestionList() if @compositionInProgress
     autoActivationEnabled = atom.config.get('autocomplete-plus.enableAutoActivation')
     wouldAutoActivate = false
-    if newText?.length
-      # Activate on space, a non-whitespace character, or a bracket-matcher pair
-      wouldAutoActivate = newText is ' ' or newText.trim().length is 1 or newText in @bracketMatcherPairs
-    else if oldText?.length
-      # Suggestion list must be either active or backspaceTriggersAutocomplete must be true for activation to occur
-      # Activate on removal of a space, a non-whitespace character, or a bracket-matcher pair
-      wouldAutoActivate = (@backspaceTriggersAutocomplete or @suggestionList.isActive()) and (oldText is ' ' or oldText.trim().length is 1 or oldText in @bracketMatcherPairs)
-    
+
+    if autoActivationEnabled
+      if newText?.length
+        # Activate on space, a non-whitespace character, or a bracket-matcher pair
+        wouldAutoActivate = newText is ' ' or newText.trim().length is 1 or newText in @bracketMatcherPairs
+      else if oldText?.length
+        # Suggestion list must be either active or backspaceTriggersAutocomplete must be true for activation to occur
+        # Activate on removal of a space, a non-whitespace character, or a bracket-matcher pair
+        wouldAutoActivate = (@backspaceTriggersAutocomplete or @suggestionList.isActive()) and (oldText is ' ' or oldText.trim().length is 1 or oldText in @bracketMatcherPairs)
+
     if autoActivationEnabled and wouldAutoActivate
       @cancelHideSuggestionListRequest()
       @requestNewSuggestions()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -86,19 +86,25 @@ module.exports =
       type: 'boolean'
       default: true
       order: 13
+    spaceTriggersAutocomplete:
+      title: 'Allow Space To Trigger Autocomplete'
+      description: 'If enabled, typing `space` will show the suggestion list if suggestions are available. If disabled, suggestions will not be shown while spacing.'
+      type: 'boolean'
+      default: false
+      order: 14
     suggestionListFollows:
       title: 'Suggestions List Follows'
       description: 'With "Cursor" the suggestion list appears at the cursor\'s position. With "Word" it appears at the beginning of the word that\'s being completed.'
       type: 'string'
       default: 'Cursor'
       enum: ['Cursor', 'Word']
-      order: 14
+      order: 15
     defaultProvider:
       description: 'Using the Symbol provider is experimental. You must reload Atom to use a new provider after changing this option.'
       type: 'string'
       default: 'Fuzzy'
       enum: ['Fuzzy', 'Symbol']
-      order: 15
+      order: 16
 
   # Public: Creates AutocompleteManager instances for all active and future editors (soon, just a single AutocompleteManager)
   activate: ->

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -86,25 +86,19 @@ module.exports =
       type: 'boolean'
       default: true
       order: 13
-    spaceTriggersAutocomplete:
-      title: 'Allow Space To Trigger Autocomplete'
-      description: 'If enabled, typing `space` will show the suggestion list if suggestions are available. If disabled, suggestions will not be shown while spacing.'
-      type: 'boolean'
-      default: false
-      order: 14
     suggestionListFollows:
       title: 'Suggestions List Follows'
       description: 'With "Cursor" the suggestion list appears at the cursor\'s position. With "Word" it appears at the beginning of the word that\'s being completed.'
       type: 'string'
       default: 'Cursor'
       enum: ['Cursor', 'Word']
-      order: 15
+      order: 14
     defaultProvider:
       description: 'Using the Symbol provider is experimental. You must reload Atom to use a new provider after changing this option.'
       type: 'string'
       default: 'Fuzzy'
       enum: ['Fuzzy', 'Symbol']
-      order: 16
+      order: 15
 
   # Public: Creates AutocompleteManager instances for all active and future editors (soon, just a single AutocompleteManager)
   activate: ->

--- a/spec/autocomplete-manager-async-spec.coffee
+++ b/spec/autocomplete-manager-async-spec.coffee
@@ -95,7 +95,7 @@ describe 'Async providers', ->
 
       runs ->
         # Waiting will kick off the suggestion request
-        editor.insertText(' ')
+        editor.insertText('\r')
         waitForAutocomplete()
 
         # Expect nothing because the provider has not come back yet

--- a/spec/autocomplete-manager-integration-spec.coffee
+++ b/spec/autocomplete-manager-integration-spec.coffee
@@ -361,7 +361,7 @@ describe 'Autocomplete Manager', ->
 
         runs ->
           expect(editorView.querySelector('.autocomplete-plus')).toExist()
-          editor.insertText(' ')
+          editor.insertText('\r')
           waitForAutocomplete()
 
         runs ->
@@ -396,7 +396,7 @@ describe 'Autocomplete Manager', ->
 
         runs ->
           expect(editorView.querySelector('.autocomplete-plus')).toExist()
-          editor.insertText(' ')
+          editor.insertText('\r')
           waitForAutocomplete()
 
         runs ->
@@ -484,7 +484,7 @@ describe 'Autocomplete Manager', ->
           editor.moveToBottom()
           editor.insertText('f')
           editor.insertText('u')
-          editor.insertText(' ')
+          editor.insertText('\r')
 
           waitForAutocomplete()
 

--- a/spec/issues/52-spec.coffee
+++ b/spec/issues/52-spec.coffee
@@ -34,7 +34,7 @@ describe 'Autocomplete', ->
       runs ->
         editorView = atom.views.getView(editor)
 
-    it 'closes the suggestion list when entering an empty string (e.g. space)', ->
+    it 'closes the suggestion list when entering an empty string (e.g. carriage return)', ->
       runs ->
         expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
 
@@ -47,6 +47,6 @@ describe 'Autocomplete', ->
         runs ->
           expect(editorView.querySelector('.autocomplete-plus')).toExist()
 
-          editor.insertText(' ')
+          editor.insertText('\r')
 
           expect(editorView.querySelector('.autocomplete-plus')).not.toExist()


### PR DESCRIPTION
- Also allow space to trigger autocomplete, disabled by default
- The size of the newText / oldText comparison logic feels dirty

@benogle this might still feel like a hack, but it doesn't create two garbage arrays on each keystroke.