### PR TITLE
Improve for manual activation

### DIFF
--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -96,6 +96,7 @@ class AutocompleteManager
     # Watch config values
     @subscriptions.add(atom.config.observe('autosave.enabled', (value) => @autosaveEnabled = value))
     @subscriptions.add(atom.config.observe('autocomplete-plus.backspaceTriggersAutocomplete', (value) => @backspaceTriggersAutocomplete = value))
+    @subscriptions.add(atom.config.observe('autocomplete-plus.enableAutoActivation', (value) => @autoActivationEnabled = value))
 
     # Handle events from suggestion list
     @subscriptions.add(@suggestionList.onDidConfirm(@confirm))
@@ -105,11 +106,11 @@ class AutocompleteManager
     @subscriptions.add atom.commands.add 'atom-text-editor',
       'autocomplete-plus:activate': =>
         @shouldDisplaySuggestions = true
-        @findSuggestions()
+        @findSuggestions(true)
 
   # Private: Finds suggestions for the current prefix, sets the list items,
   # positions the overlay and shows it
-  findSuggestions: =>
+  findSuggestions: (activatedManually) =>
     return if @disposed
     return unless @providerManager? and @editor? and @buffer?
     return if @isCurrentFileBlackListed()
@@ -120,9 +121,9 @@ class AutocompleteManager
     scopeDescriptor = cursor.getScopeDescriptor()
     prefix = @getPrefix(@editor, bufferPosition)
 
-    @getSuggestionsFromProviders({@editor, bufferPosition, scopeDescriptor, prefix})
+    @getSuggestionsFromProviders({@editor, bufferPosition, scopeDescriptor, prefix}, activatedManually)
 
-  getSuggestionsFromProviders: (options) =>
+  getSuggestionsFromProviders: (options, activatedManually) =>
     providers = @providerManager.providersForScopeDescriptor(options.scopeDescriptor)
 
     providerPromises = []
@@ -173,7 +174,11 @@ class AutocompleteManager
     @currentSuggestionsPromise = suggestionsPromise = Promise.all(providerPromises)
       .then(@mergeSuggestionsFromProviders)
       .then (suggestions) =>
-        if @currentSuggestionsPromise is suggestionsPromise
+        return unless @currentSuggestionsPromise is suggestionsPromise
+        if activatedManually and @shouldDisplaySuggestions and suggestions.length is 1
+          # When there is one suggestion in manual mode, just confirm it
+          @confirm(suggestions[0])
+        else
           @displaySuggestions(suggestions, options)
 
   # providerSuggestions - array of arrays of suggestions provided by all called providers
@@ -361,10 +366,9 @@ class AutocompleteManager
   bufferChanged: ({newText, oldText}) =>
     return if @disposed
     return @hideSuggestionList() if @compositionInProgress
-    autoActivationEnabled = atom.config.get('autocomplete-plus.enableAutoActivation')
     shouldActivate = false
 
-    if autoActivationEnabled or @suggestionList.isActive()
+    if @autoActivationEnabled or @suggestionList.isActive()
       if newText?.length
         # Activate on space, a non-whitespace character, or a bracket-matcher pair
         shouldActivate = newText is ' ' or newText.trim().length is 1 or newText in @bracketMatcherPairs

--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -364,14 +364,14 @@ class AutocompleteManager
     autoActivationEnabled = atom.config.get('autocomplete-plus.enableAutoActivation')
     shouldActivate = false
 
-    if @suggestionList.isActive() or autoActivationEnabled
+    if autoActivationEnabled or @suggestionList.isActive()
       if newText?.length
         # Activate on space, a non-whitespace character, or a bracket-matcher pair
         shouldActivate = newText is ' ' or newText.trim().length is 1 or newText in @bracketMatcherPairs
-      else if oldText?.length
+      else if oldText?.length and (@backspaceTriggersAutocomplete or @suggestionList.isActive())
         # Suggestion list must be either active or backspaceTriggersAutocomplete must be true for activation to occur
         # Activate on removal of a space, a non-whitespace character, or a bracket-matcher pair
-        shouldActivate = (@backspaceTriggersAutocomplete or @suggestionList.isActive()) and (oldText is ' ' or oldText.trim().length is 1 or oldText in @bracketMatcherPairs)
+        shouldActivate = oldText is ' ' or oldText.trim().length is 1 or oldText in @bracketMatcherPairs
 
     if shouldActivate
       @cancelHideSuggestionListRequest()

--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -362,18 +362,18 @@ class AutocompleteManager
     return if @disposed
     return @hideSuggestionList() if @compositionInProgress
     autoActivationEnabled = atom.config.get('autocomplete-plus.enableAutoActivation')
-    wouldAutoActivate = false
+    shouldActivate = false
 
-    if autoActivationEnabled
+    if @suggestionList.isActive() or autoActivationEnabled
       if newText?.length
         # Activate on space, a non-whitespace character, or a bracket-matcher pair
-        wouldAutoActivate = newText is ' ' or newText.trim().length is 1 or newText in @bracketMatcherPairs
+        shouldActivate = newText is ' ' or newText.trim().length is 1 or newText in @bracketMatcherPairs
       else if oldText?.length
         # Suggestion list must be either active or backspaceTriggersAutocomplete must be true for activation to occur
         # Activate on removal of a space, a non-whitespace character, or a bracket-matcher pair
-        wouldAutoActivate = (@backspaceTriggersAutocomplete or @suggestionList.isActive()) and (oldText is ' ' or oldText.trim().length is 1 or oldText in @bracketMatcherPairs)
+        shouldActivate = (@backspaceTriggersAutocomplete or @suggestionList.isActive()) and (oldText is ' ' or oldText.trim().length is 1 or oldText in @bracketMatcherPairs)
 
-    if autoActivationEnabled and wouldAutoActivate
+    if shouldActivate
       @cancelHideSuggestionListRequest()
       @requestNewSuggestions()
     else

--- a/spec/autocomplete-manager-integration-spec.coffee
+++ b/spec/autocomplete-manager-integration-spec.coffee
@@ -328,6 +328,23 @@ describe 'Autocomplete Manager', ->
         runs ->
           expect(editorView.querySelector('.autocomplete-plus')).toExist()
 
+      it "stays open when typing", ->
+        triggerAutocompletion(editor, false, 'a')
+
+        runs ->
+          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+          atom.commands.dispatch(editorView, 'autocomplete-plus:activate')
+          waitForAutocomplete()
+
+        runs ->
+          expect(editorView.querySelector('.autocomplete-plus')).toExist()
+
+          editor.insertText('b')
+          waitForAutocomplete()
+
+        runs ->
+          expect(editorView.querySelector('.autocomplete-plus')).toExist()
+
     describe "when the replacementPrefix doesnt match the actual prefix", ->
       describe "when snippets are not used", ->
         beforeEach ->

--- a/spec/autocomplete-manager-integration-spec.coffee
+++ b/spec/autocomplete-manager-integration-spec.coffee
@@ -345,6 +345,42 @@ describe 'Autocomplete Manager', ->
         runs ->
           expect(editorView.querySelector('.autocomplete-plus')).toExist()
 
+      it 'accepts the suggestion if there is one', ->
+        spyOn(provider, 'getSuggestions').andCallFake (options) ->
+          [text: 'omgok']
+
+        triggerAutocompletion(editor)
+
+        runs ->
+          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+          atom.commands.dispatch(editorView, 'autocomplete-plus:activate')
+          waitForAutocomplete()
+
+        runs ->
+          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+          expect(editor.getText()).toBe 'omgok'
+
+      it 'does not auto-accept a single suggestion when filtering', ->
+        spyOn(provider, 'getSuggestions').andCallFake ({prefix}) ->
+          list = _.filter ['a', 'abc'], (word) -> word.indexOf(prefix) is 0
+          ({text: t} for t in list)
+
+        editor.insertText('a')
+        atom.commands.dispatch(editorView, 'autocomplete-plus:activate')
+        waitForAutocomplete()
+
+        runs ->
+          expect(editorView.querySelector('.autocomplete-plus')).toExist()
+          expect(editorView.querySelectorAll('.autocomplete-plus li')).toHaveLength 2
+
+          editor.insertText('b')
+          waitForAutocomplete()
+
+        runs ->
+          expect(editorView.querySelector('.autocomplete-plus')).toExist()
+          expect(editorView.querySelectorAll('.autocomplete-plus li')).toHaveLength 1
+
+
     describe "when the replacementPrefix doesnt match the actual prefix", ->
       describe "when snippets are not used", ->
         beforeEach ->


### PR DESCRIPTION
* The suggestion box would close when typing subsequent characters
* When manual mode is triggered and there is only one suggestion, dont show the UI, just confirm it.

@nathansobo can you get this branch and try it out?

TODO (maybe) 

* [ ] strict match the initial activation prefix, then fuzzy match the rest