### PR TITLE
Suppress Activation For EditorView Classes

### DIFF
--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -103,7 +103,7 @@ class AutocompleteManager
       unless value?.length
         @suppressForClasses = []
         return
-      @suppressForClasses = _.chain(value).map((s) -> s?.trim().split('.')).compact().value()
+      @suppressForClasses = _.chain(value).map((classNames) -> classNames?.trim().split('.')).compact().value()
 
     # Handle events from suggestion list
     @subscriptions.add(@suggestionList.onDidConfirm(@confirm))

--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -402,7 +402,7 @@ class AutocompleteManager
       # Suppress activation if the editorView has classes that match the suppression list
       if shouldActivate and editorView?.classList? and atom.config.get('autocomplete-plus.suppressActivationForEditorClasses')?.length
         for item in @suppressForClasses
-          shouldActivate = false if _.intersection(editorView.classList, item)?.length
+          shouldActivate = false if _.intersection(editorView.classList, item)?.length is item.length
 
     if shouldActivate
       @cancelHideSuggestionListRequest()

--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -401,8 +401,8 @@ class AutocompleteManager
 
       # Suppress activation if the editorView has classes that match the suppression list
       if shouldActivate
-        for item in @suppressForClasses
-          shouldActivate = false if _.intersection(@editorView.classList, item)?.length is item.length
+        for classNames in @suppressForClasses
+          shouldActivate = false if _.intersection(@editorView.classList, classNames)?.length is classNames.length
 
     if shouldActivate
       @cancelHideSuggestionListRequest()

--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -103,7 +103,7 @@ class AutocompleteManager
       unless value?.length
         @suppressForClasses = []
         return
-      @suppressForClasses = _.chain(value).reject((s) -> s.trim() is '').map((s) -> s.trim()).map((s) -> s.split('.')).value()
+      @suppressForClasses = _.chain(value).map((s) -> s?.trim().split('.')).compact().value()
 
     # Handle events from suggestion list
     @subscriptions.add(@suggestionList.onDidConfirm(@confirm))

--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -400,9 +400,9 @@ class AutocompleteManager
         shouldActivate = oldText is ' ' or oldText.trim().length is 1 or oldText in @bracketMatcherPairs
 
       # Suppress activation if the editorView has classes that match the suppression list
-      if shouldActivate and editorView?.classList? and atom.config.get('autocomplete-plus.suppressActivationForEditorClasses')?.length
+      if shouldActivate and @editorView?.classList? and @suppressForClasses?.length
         for item in @suppressForClasses
-          shouldActivate = false if _.intersection(editorView.classList, item)?.length is item.length
+          shouldActivate = false if _.intersection(@editorView.classList, item)?.length is item.length
 
     if shouldActivate
       @cancelHideSuggestionListRequest()

--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -100,9 +100,6 @@ class AutocompleteManager
     @subscriptions.add(atom.config.observe('autocomplete-plus.backspaceTriggersAutocomplete', (value) => @backspaceTriggersAutocomplete = value))
     @subscriptions.add(atom.config.observe('autocomplete-plus.enableAutoActivation', (value) => @autoActivationEnabled = value))
     @subscriptions.add atom.config.observe 'autocomplete-plus.suppressActivationForEditorClasses', (value) =>
-      unless value?.length
-        @suppressForClasses = []
-        return
       @suppressForClasses = _.chain(value).map((classNames) -> classNames?.trim().split('.').map((className) -> className?.trim())).compact().value()
 
     # Handle events from suggestion list

--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -103,7 +103,7 @@ class AutocompleteManager
       unless value?.length
         @suppressForClasses = []
         return
-      @suppressForClasses = _.chain(value).map((classNames) -> classNames?.trim().split('.')).compact().value()
+      @suppressForClasses = _.chain(value).map((classNames) -> classNames?.trim().split('.').map((className) -> className?.trim())).compact().value()
 
     # Handle events from suggestion list
     @subscriptions.add(@suggestionList.onDidConfirm(@confirm))

--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -400,7 +400,7 @@ class AutocompleteManager
         shouldActivate = oldText is ' ' or oldText.trim().length is 1 or oldText in @bracketMatcherPairs
 
       # Suppress activation if the editorView has classes that match the suppression list
-      if shouldActivate and @editorView?.classList? and @suppressForClasses?.length
+      if shouldActivate
         for item in @suppressForClasses
           shouldActivate = false if _.intersection(@editorView.classList, item)?.length is item.length
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -99,6 +99,14 @@ module.exports =
       default: 'Fuzzy'
       enum: ['Fuzzy', 'Symbol']
       order: 15
+    suppressActivationForEditorClasses:
+      title: 'Suppress Activation For Editor Classes'
+      description: 'Don\'t auto-activate when any of these classes are present in the editor.'
+      type: 'array'
+      default: ['vim-mode.insert-mode']
+      items:
+        type: 'string'
+      order: 16
 
   # Public: Creates AutocompleteManager instances for all active and future editors (soon, just a single AutocompleteManager)
   activate: ->

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -103,7 +103,7 @@ module.exports =
       title: 'Suppress Activation For Editor Classes'
       description: 'Don\'t auto-activate when any of these classes are present in the editor.'
       type: 'array'
-      default: ['vim-mode.insert-mode']
+      default: ['vim-mode.command-mode', 'vim-mode.visual-mode', 'vim-mode.operator-pending-mode']
       items:
         type: 'string'
       order: 16

--- a/spec/autocomplete-manager-integration-spec.coffee
+++ b/spec/autocomplete-manager-integration-spec.coffee
@@ -60,11 +60,15 @@ describe 'Autocomplete Manager', ->
         expect(triggerPosition).toEqual [0, 1]
         expect(suggestion.text).toBe 'ab'
 
-    describe "suppression for editorView classes", ->
+    fdescribe "suppression for editorView classes", ->
       beforeEach ->
-        editorView.classList.add('vim-mode')
+        atom.config.set('autocomplete-plus.suppressActivationForEditorClasses', ['vim-mode.command-mode', 'vim-mode . visual-mode', ' vim-mode.operator-pending-mode ', ' '])
 
       it 'should show the suggestion list when the suppression list does not match', ->
+        runs ->
+          editorView.classList.add('vim-mode')
+          editorView.classList.add('insert-mode')
+
         runs ->
           expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
           triggerAutocompletion(editor)
@@ -74,6 +78,7 @@ describe 'Autocomplete Manager', ->
 
       it 'should not show the suggestion list when the suppression list does match', ->
         runs ->
+          editorView.classList.add('vim-mode')
           editorView.classList.add('command-mode')
 
         runs ->
@@ -82,6 +87,53 @@ describe 'Autocomplete Manager', ->
 
         runs ->
           expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+
+      it 'should not show the suggestion list when the suppression list does match', ->
+        runs ->
+          editorView.classList.add('vim-mode')
+          editorView.classList.add('operator-pending-mode')
+
+        runs ->
+          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+          triggerAutocompletion(editor)
+
+        runs ->
+          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+
+      it 'should not show the suggestion list when the suppression list does match', ->
+        runs ->
+          editorView.classList.add('vim-mode')
+          editorView.classList.add('visual-mode')
+
+        runs ->
+          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+          triggerAutocompletion(editor)
+
+        runs ->
+          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+
+      it 'should show the suggestion list when the suppression list does not match', ->
+        runs ->
+          editorView.classList.add('vim-mode')
+          editorView.classList.add('some-unforeseen-mode')
+
+        runs ->
+          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+          triggerAutocompletion(editor)
+
+        runs ->
+          expect(editorView.querySelector('.autocomplete-plus')).toExist()
+
+      it 'should show the suggestion list when the suppression list does not match', ->
+        runs ->
+          editorView.classList.add('command-mode')
+
+        runs ->
+          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+          triggerAutocompletion(editor)
+
+        runs ->
+          expect(editorView.querySelector('.autocomplete-plus')).toExist()
 
     describe "prefix passed to getSuggestions", ->
       prefix = null

--- a/spec/autocomplete-manager-integration-spec.coffee
+++ b/spec/autocomplete-manager-integration-spec.coffee
@@ -702,6 +702,38 @@ describe 'Autocomplete Manager', ->
           for item, index in editorView.querySelectorAll('.autocomplete-plus li span.word')
             expect(item.innerText).toEqual(suggestions[index])
 
+      it 'should show the suggestion list when the suppression list does not match', ->
+        runs ->
+          editorView.classList.add('vim-mode')
+
+        runs ->
+          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+
+          # Trigger an autocompletion
+          triggerAutocompletion(editor)
+
+        runs ->
+          expect(editorView.querySelector('.autocomplete-plus')).toExist()
+
+          # Check suggestions
+          suggestions = ['function', 'if', 'left', 'shift']
+          for item, index in editorView.querySelectorAll('.autocomplete-plus li span.word')
+            expect(item.innerText).toEqual(suggestions[index])
+
+      it 'should not show the suggestion list when the suppression list does match', ->
+        runs ->
+          editorView.classList.add('vim-mode')
+          editorView.classList.add('insert-mode')
+
+        runs ->
+          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+
+          # Trigger an autocompletion
+          triggerAutocompletion(editor)
+
+        runs ->
+          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+
       it 'should not show the suggestion list when no suggestions are found', ->
         expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
 

--- a/spec/autocomplete-manager-integration-spec.coffee
+++ b/spec/autocomplete-manager-integration-spec.coffee
@@ -60,6 +60,29 @@ describe 'Autocomplete Manager', ->
         expect(triggerPosition).toEqual [0, 1]
         expect(suggestion.text).toBe 'ab'
 
+    describe "suppression for editorView classes", ->
+      beforeEach ->
+        editorView.classList.add('vim-mode')
+
+      it 'should show the suggestion list when the suppression list does not match', ->
+        runs ->
+          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+          triggerAutocompletion(editor)
+
+        runs ->
+          expect(editorView.querySelector('.autocomplete-plus')).toExist()
+
+      it 'should not show the suggestion list when the suppression list does match', ->
+        runs ->
+          editorView.classList.add('command-mode')
+
+        runs ->
+          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+          triggerAutocompletion(editor)
+
+        runs ->
+          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+
     describe "prefix passed to getSuggestions", ->
       prefix = null
       beforeEach ->
@@ -680,8 +703,6 @@ describe 'Autocomplete Manager', ->
       it 'should not show the suggestion list', ->
         atom.config.set('autocomplete-plus.enableBuiltinProvider', false)
         expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-
-        # Trigger an autocompletion
         triggerAutocompletion(editor)
 
         runs ->
@@ -690,8 +711,6 @@ describe 'Autocomplete Manager', ->
     describe 'when the buffer changes', ->
       it 'should show the suggestion list when suggestions are found', ->
         expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-
-        # Trigger an autocompletion
         triggerAutocompletion(editor)
 
         runs ->
@@ -702,42 +721,9 @@ describe 'Autocomplete Manager', ->
           for item, index in editorView.querySelectorAll('.autocomplete-plus li span.word')
             expect(item.innerText).toEqual(suggestions[index])
 
-      it 'should show the suggestion list when the suppression list does not match', ->
-        runs ->
-          editorView.classList.add('vim-mode')
-
-        runs ->
-          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-
-          # Trigger an autocompletion
-          triggerAutocompletion(editor)
-
-        runs ->
-          expect(editorView.querySelector('.autocomplete-plus')).toExist()
-
-          # Check suggestions
-          suggestions = ['function', 'if', 'left', 'shift']
-          for item, index in editorView.querySelectorAll('.autocomplete-plus li span.word')
-            expect(item.innerText).toEqual(suggestions[index])
-
-      it 'should not show the suggestion list when the suppression list does match', ->
-        runs ->
-          editorView.classList.add('vim-mode')
-          editorView.classList.add('insert-mode')
-
-        runs ->
-          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-
-          # Trigger an autocompletion
-          triggerAutocompletion(editor)
-
-        runs ->
-          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-
       it 'should not show the suggestion list when no suggestions are found', ->
         expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
 
-        # Trigger an autocompletion
         editor.moveToBottom()
         editor.insertText('x')
 
@@ -750,7 +736,6 @@ describe 'Autocomplete Manager', ->
         runs ->
           expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
 
-          # Trigger an autocompletion
           editor.moveToBottom()
           editor.insertText('f')
           editor.insertText('u')
@@ -785,7 +770,6 @@ describe 'Autocomplete Manager', ->
           atom.config.set('autocomplete-plus.backspaceTriggersAutocomplete', false)
           expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
 
-          # Trigger an autocompletion
           editor.moveToBottom()
           editor.insertText('f')
           editor.insertText('u')
@@ -818,7 +802,6 @@ describe 'Autocomplete Manager', ->
       it "keeps the suggestion list open when it's already open on backspace", ->
         expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
 
-        # Trigger an autocompletion
         editor.moveToBottom()
         editor.insertText('f')
         editor.insertText('u')
@@ -841,7 +824,6 @@ describe 'Autocomplete Manager', ->
         atom.config.set('autocomplete-plus.backspaceTriggersAutocomplete', false)
         expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
 
-        # Trigger an autocompletion
         editor.setCursorBufferPosition([2, 39]) # at the end of `items`
 
         runs ->
@@ -892,7 +874,6 @@ describe 'Autocomplete Manager', ->
     describe 'select-previous event', ->
       it 'selects the previous item in the list', ->
 
-        # Trigger an autocompletion
         triggerAutocompletion(editor, false, 'a')
 
         runs ->
@@ -911,7 +892,6 @@ describe 'Autocomplete Manager', ->
           expect(items[2]).toHaveClass('selected')
 
       it 'closes the autocomplete when up arrow pressed when only one item displayed', ->
-        # Trigger an autocompletion
         triggerAutocompletion(editor, false, 'q')
 
         runs ->
@@ -924,7 +904,6 @@ describe 'Autocomplete Manager', ->
           expect(autocomplete).not.toExist()
 
       it 'does not close the autocomplete when down arrow pressed when many items', ->
-        # Trigger an autocompletion
         triggerAutocompletion(editor)
 
         runs ->
@@ -937,7 +916,6 @@ describe 'Autocomplete Manager', ->
 
       it 'does close the autocomplete when down arrow while up,down navigation not selected', ->
         atom.config.set('autocomplete-plus.navigateCompletions', 'ctrl-p,ctrl-n')
-        # Trigger an autocompletion
         triggerAutocompletion(editor, false)
 
         runs ->
@@ -951,7 +929,6 @@ describe 'Autocomplete Manager', ->
 
     describe 'select-next event', ->
       it 'selects the next item in the list', ->
-        # Trigger an autocompletion
         triggerAutocompletion(editor, false, 'a')
 
         runs ->
@@ -971,7 +948,6 @@ describe 'Autocomplete Manager', ->
           expect(items[2]).not.toHaveClass('selected')
 
       it 'closes the autocomplete when up arrow pressed when only one item displayed', ->
-        # Trigger an autocompletion
         triggerAutocompletion(editor, false, 'q')
 
         runs ->
@@ -984,7 +960,6 @@ describe 'Autocomplete Manager', ->
           expect(autocomplete).not.toExist()
 
       it 'does not close the autocomplete when up arrow pressed when many items', ->
-        # Trigger an autocompletion
         triggerAutocompletion(editor)
 
         runs ->
@@ -997,7 +972,6 @@ describe 'Autocomplete Manager', ->
 
       it 'does close the autocomplete when up arrow while up,down navigation not selected', ->
         atom.config.set('autocomplete-plus.navigateCompletions', 'ctrl-p,ctrl-n')
-        # Trigger an autocompletion
         triggerAutocompletion(editor)
 
         runs ->
@@ -1011,7 +985,6 @@ describe 'Autocomplete Manager', ->
 
     describe 'when a suggestion is clicked', ->
       it 'should select the item and confirm the selection', ->
-        # Trigger an autocompletion
         triggerAutocompletion(editor, true, 'a')
 
         runs ->


### PR DESCRIPTION
This is an initial attempt at suppressing activation for vim-mode when insert-mode is active, but in a way that is configurable and extensible.

@benogle thoughts on how we might test for this without explicitly requiring vim-mode to be installed for a developer or the CI builds?