### PR TITLE
 Add possibility for docstring display

### DIFF
--- a/lib/suggestion-list-element.coffee
+++ b/lib/suggestion-list-element.coffee
@@ -47,9 +47,17 @@ class SuggestionListElement extends HTMLElement
       event.stopPropagation()
       @confirmSelection()
 
+  updateDoc: ->
+    if @visibleItems()[@selectedIndex]['description']?
+      @docDiv.style.display = 'block'
+      @docSpan.textContent = @visibleItems()[@selectedIndex]['description']
+    else
+      @docDiv.style.display = 'none'
+
   itemsChanged: ->
     @selectedIndex = 0
     @renderItems()
+    @updateDoc()
 
   addActiveClassToEditor: ->
     editorElement = atom.views.getView(atom.workspace.getActiveTextEditor())
@@ -74,6 +82,7 @@ class SuggestionListElement extends HTMLElement
   setSelectedIndex: (index) ->
     @selectedIndex = index
     @renderItems()
+    @updateDoc()
 
   visibleItems: ->
     @model?.items?.slice(0, @maxItems)
@@ -95,9 +104,22 @@ class SuggestionListElement extends HTMLElement
       @model.cancel()
 
   renderList: ->
+    @mainDiv = document.createElement('div')
+
     @ol = document.createElement('ol')
-    @appendChild(@ol)
     @ol.className = 'list-group'
+    @mainDiv.appendChild(@ol)
+
+    @docDiv = document.createElement('div')
+    @docDiv.className = 'docstring'
+    ruler = document.createElement('hr')
+    @docDiv.appendChild(ruler)
+    @docSpan = document.createElement('span')
+    @docSpan.className = 'docstring'
+    @docDiv.appendChild(@docSpan)
+
+    @mainDiv.appendChild(@docDiv)
+    @appendChild(@mainDiv)
 
   calculateMaxListHeight: ->
     maxVisibleItems = atom.config.get('autocomplete-plus.maxVisibleSuggestions')

--- a/styles/autocomplete.less
+++ b/styles/autocomplete.less
@@ -6,6 +6,20 @@ autocomplete-suggestion-list.select-list.popover-list {
   width: auto;
   display: inline-block;
   min-width: 200px;
+  max-width: 700px;
+
+  .docstring {
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
+
+  hr {
+    margin: 4px;
+    height: 1px;
+    background-color: @text-color-subtle;
+    color: @text-color-subtle;
+  }
 
   input {
     position: absolute;


### PR DESCRIPTION
No Markdown rendering yet, since it's not clear which subset of markdown to allow (and how to enforce this).

![2015-04-01-214559_1920x1200_scrot](https://cloud.githubusercontent.com/assets/442687/6954359/148b700a-d8d1-11e4-8703-b17daa7ef0cc.png)
![2015-04-01-214859_1920x1200_scrot](https://cloud.githubusercontent.com/assets/442687/6954364/17c6e4d4-d8d1-11e4-8940-1ba20ee7476a.png)

Closes #279 