### PR TITLE
Fix spec atom 190

### DIFF
--- a/spec/autocomplete-manager-integration-spec.coffee
+++ b/spec/autocomplete-manager-integration-spec.coffee
@@ -379,7 +379,8 @@ describe 'Autocomplete Manager', ->
           expect(overlayElement).toExist()
 
           left = editorView.pixelPositionForBufferPosition([0, 2]).left
-          expect(overlayElement.style.left).toBe "#{left}px"
+          gutterWidth = editorView.shadowRoot.querySelector('.gutter').offsetWidth
+          expect(overlayElement.style.left).toBe "#{left + gutterWidth}px"
 
           atom.commands.dispatch(editorView, 'autocomplete-plus:cancel')
           expect(editorView.querySelector('.autocomplete-plus')).not.toExist()


### PR DESCRIPTION
The overlay will have a new parent as of atom 190, and this calc will need to take into account the gutter width.

Dont merge til 190 is out.