### PR TITLE
Docstring in suggestions

### DIFF
--- a/lib/suggestion-list-element.coffee
+++ b/lib/suggestion-list-element.coffee
@@ -61,10 +61,19 @@ class SuggestionListElement extends HTMLElement
       event.stopPropagation()
       @confirmSelection()
 
+  updateDoc: ->
+    if @visibleItems()[@selectedIndex]['description']?
+      @docDiv.style.display = 'block'
+      @docSpan.textContent = @visibleItems()[@selectedIndex]['description']
+    else
+      @docDiv.style.display = 'none'
+
   itemsChanged: ->
     @selectedIndex = 0
     atom.views.pollAfterNextUpdate?()
-    atom.views.updateDocument => @renderItems()
+    atom.views.updateDocument =>
+      @renderItems()
+      @updateDoc()
 
   addActiveClassToEditor: ->
     editorElement = atom.views.getView(atom.workspace.getActiveTextEditor())
@@ -89,6 +98,7 @@ class SuggestionListElement extends HTMLElement
   setSelectedIndex: (index) ->
     @selectedIndex = index
     @renderItems()
+    @updateDoc()
 
   visibleItems: ->
     @model?.items?.slice(0, @maxItems)
@@ -110,9 +120,22 @@ class SuggestionListElement extends HTMLElement
       @model.cancel()
 
   renderList: ->
+    @mainDiv = document.createElement('div')
+
     @ol = document.createElement('ol')
-    @appendChild(@ol)
     @ol.className = 'list-group'
+    @mainDiv.appendChild(@ol)
+
+    @docDiv = document.createElement('div')
+    @docDiv.className = 'docstring'
+    ruler = document.createElement('hr')
+    @docDiv.appendChild(ruler)
+    @docSpan = document.createElement('span')
+    @docSpan.className = 'docstring'
+    @docDiv.appendChild(@docSpan)
+
+    @mainDiv.appendChild(@docDiv)
+    @appendChild(@mainDiv)
 
   calculateMaxListHeight: ->
     maxVisibleItems = atom.config.get('autocomplete-plus.maxVisibleSuggestions')

--- a/lib/suggestion-list-element.coffee
+++ b/lib/suggestion-list-element.coffee
@@ -127,11 +127,11 @@ class SuggestionListElement extends HTMLElement
     @mainDiv.appendChild(@ol)
 
     @docDiv = document.createElement('div')
-    @docDiv.className = 'docstring'
+    @docDiv.className = 'suggestion-description'
     ruler = document.createElement('hr')
     @docDiv.appendChild(ruler)
     @docSpan = document.createElement('span')
-    @docSpan.className = 'docstring'
+    @docSpan.className = 'suggestion-description'
     @docDiv.appendChild(@docSpan)
 
     @mainDiv.appendChild(@docDiv)

--- a/lib/suggestion-list-element.coffee
+++ b/lib/suggestion-list-element.coffee
@@ -10,6 +10,14 @@ ItemTemplate = """
   </span>
 """
 
+ListTemplate = """
+  <ol class="list-group"></ol>
+  <div class="suggestion-description">
+    <hr />
+    <span class="suggestion-description"></span>
+  </div>
+"""
+
 IconTemplate = '<i class="icon"></i>'
 
 DefaultSuggestionTypeIconHTML =
@@ -62,7 +70,7 @@ class SuggestionListElement extends HTMLElement
       @confirmSelection()
 
   updateDoc: ->
-    if @visibleItems()[@selectedIndex]['description']?
+    if @visibleItems()[@selectedIndex]['description']? and @visibleItems()[@selectedIndex]['description'].length > 0
       @docDiv.style.display = 'block'
       @docSpan.textContent = @visibleItems()[@selectedIndex]['description']
     else
@@ -121,20 +129,13 @@ class SuggestionListElement extends HTMLElement
 
   renderList: ->
     @mainDiv = document.createElement('div')
+    @mainDiv.innerHTML = ListTemplate
 
-    @ol = document.createElement('ol')
-    @ol.className = 'list-group'
-    @mainDiv.appendChild(@ol)
+    @ol = @mainDiv.getElementsByClassName("list-group")[0]
 
-    @docDiv = document.createElement('div')
-    @docDiv.className = 'suggestion-description'
-    ruler = document.createElement('hr')
-    @docDiv.appendChild(ruler)
-    @docSpan = document.createElement('span')
-    @docSpan.className = 'suggestion-description'
-    @docDiv.appendChild(@docSpan)
+    @docDiv = @mainDiv.querySelector('div.suggestion-description')
+    @docSpan = @mainDiv.querySelector('span.suggestion-description')
 
-    @mainDiv.appendChild(@docDiv)
     @appendChild(@mainDiv)
 
   calculateMaxListHeight: ->

--- a/spec/provider-api-spec.coffee
+++ b/spec/provider-api-spec.coffee
@@ -83,6 +83,7 @@ describe 'Provider API', ->
             text: 'ohai',
             replacementPrefix: 'o',
             rightLabelHTML: '<span style="color: red">ohai</span>',
+            description: 'There be documentation'
           ]
       registration = atom.packages.serviceHub.provide('autocomplete.provider', '2.0.0', testProvider)
 
@@ -92,3 +93,4 @@ describe 'Provider API', ->
         suggestionListView = atom.views.getView(autocompleteManager.suggestionList)
         expect(suggestionListView.querySelector('li .right-label')).toHaveHtml('<span style="color: red">ohai</span>')
         expect(suggestionListView.querySelector('span.word')).toHaveText('ohai')
+        expect(suggestionListView.querySelector('span.docstring').toHaveText('There be documentation'))

--- a/spec/provider-api-spec.coffee
+++ b/spec/provider-api-spec.coffee
@@ -93,4 +93,4 @@ describe 'Provider API', ->
         suggestionListView = atom.views.getView(autocompleteManager.suggestionList)
         expect(suggestionListView.querySelector('li .right-label')).toHaveHtml('<span style="color: red">ohai</span>')
         expect(suggestionListView.querySelector('span.word')).toHaveText('ohai')
-        expect(suggestionListView.querySelector('span.docstring').toHaveText('There be documentation'))
+        expect(suggestionListView.querySelector('span.suggestion-description').toHaveText('There be documentation'))

--- a/spec/provider-api-spec.coffee
+++ b/spec/provider-api-spec.coffee
@@ -93,4 +93,4 @@ describe 'Provider API', ->
         suggestionListView = atom.views.getView(autocompleteManager.suggestionList)
         expect(suggestionListView.querySelector('li .right-label')).toHaveHtml('<span style="color: red">ohai</span>')
         expect(suggestionListView.querySelector('span.word')).toHaveText('ohai')
-        expect(suggestionListView.querySelector('span.suggestion-description').toHaveText('There be documentation'))
+        expect(suggestionListView.querySelector('span.suggestion-description')).toHaveText('There be documentation')

--- a/styles/autocomplete.less
+++ b/styles/autocomplete.less
@@ -16,6 +16,20 @@ autocomplete-suggestion-list.select-list.popover-list {
   min-width: 200px;
   overflow-y: auto;
   padding: 0;
+  max-width: 700px;
+
+  .docstring {
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
+
+  hr {
+    margin: 4px;
+    height: 1px;
+    background-color: @text-color-subtle;
+    color: @text-color-subtle;
+  }
 
   input {
     position: absolute;

--- a/styles/autocomplete.less
+++ b/styles/autocomplete.less
@@ -18,7 +18,7 @@ autocomplete-suggestion-list.select-list.popover-list {
   padding: 0;
   max-width: 700px;
 
-  .docstring {
+  .suggestion-description {
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;


### PR DESCRIPTION
I moved this from #347 to here, since I originally forgot to open a feature branch. Sorry about that.

I have now:
* Rebased
* Used a template
* Written a Spec for the display of the docstring

Regarding the spec: I am not entirely certain if that worked. If I run my package specs, Atom tells me "6/6 successful, 120 skipped". Im am not sure if the new spec is skipped (and if so, why), or how to tell Atom not to skip any specs...