### PR TITLE
Suggestion Sorting

### DIFF
--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -243,9 +243,24 @@ class AutocompleteManager
       """
     hasDeprecations
 
+  sortSuggestions: (suggestions, {prefix}) =>
+    pattern = prefix.replace(/[^a-zA-Z0-9]+/g, '')
+    pattern = new RegExp('^' + pattern, 'i')
+
+    # Sort the most likely (startswith) candidates first
+    startswith = []
+    remainder = []
+    for item in suggestions
+      if (item.text || item.snippet).match(pattern)
+        startswith.push(item)
+      else
+        remainder.push(item)
+    startswith.concat(remainder)
+
   displaySuggestions: (suggestions, options) =>
     suggestions = _.uniq(suggestions, (s) -> s.text + s.snippet)
     if @shouldDisplaySuggestions and suggestions.length
+      suggestions = @sortSuggestions(suggestions, options)
       @showSuggestionList(suggestions)
     else
       @hideSuggestionList()


### PR DESCRIPTION
I'm currently writing a clang provider for autocomplete-plus. When there is a very large list of suggestions the usability of the plugin goes through the floor. With languages C++ in some cases you might have to scroll through 100s of items in order to reach the item you are looking for, so getting the most relevant results to the top becomes important.

**Before:**
![Before](https://cloud.githubusercontent.com/assets/522465/7013142/4591901e-dcb7-11e4-8bf6-677c607d05ef.png)

A big improvement simply comes from simply moving items that `startsWith` to the top of the suggestions list.

**After:**
![After](https://cloud.githubusercontent.com/assets/522465/7013157/585bb8be-dcb7-11e4-94d2-c633c88c5f27.png)
