### PR TITLE
Align replacement to prefix when suggestionListFollows is 'Word'

### DIFF
--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -247,7 +247,7 @@ class AutocompleteManager
   displaySuggestions: (suggestions, options) =>
     suggestions = _.uniq(suggestions, (s) -> s.text + s.snippet)
     if @shouldDisplaySuggestions and suggestions.length
-      @showSuggestionList(suggestions)
+      @showSuggestionList(suggestions, options)
     else
       @hideSuggestionList()
 
@@ -279,10 +279,10 @@ class AutocompleteManager
     else
       suggestion.onDidConfirm?()
 
-  showSuggestionList: (suggestions) ->
+  showSuggestionList: (suggestions, options) ->
     return if @disposed
     @suggestionList.changeItems(suggestions)
-    @suggestionList.show(@editor)
+    @suggestionList.show(@editor, options)
 
   hideSuggestionList: =>
     return if @disposed

--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -163,6 +163,7 @@ class AutocompleteManager
               snippet: suggestion.snippet
               replacementPrefix: suggestion.replacementPrefix ? suggestion.prefix
               className: suggestion.className
+              type: suggestion.type
             newSuggestion.rightLabelHTML = suggestion.label if not newSuggestion.rightLabelHTML? and suggestion.renderLabelAsHtml
             newSuggestion.rightLabel = suggestion.label if not newSuggestion.rightLabel? and not suggestion.renderLabelAsHtml
             newSuggestion

--- a/lib/suggestion-list-element.coffee
+++ b/lib/suggestion-list-element.coffee
@@ -130,6 +130,12 @@ class SuggestionListElement extends HTMLElement
     li.remove() while li = @ol.childNodes[items.length]
     @selectedLi?.scrollIntoView(false)
 
+    firstChild = @ol.childNodes[0]
+    wordContainer = firstChild?.querySelector('.word-container')
+    marginLeft = 0
+    marginLeft = -wordContainer.offsetLeft if wordContainer?
+    @style['margin-left'] = "#{marginLeft}px"
+
   renderItem: ({iconHTML, type, snippet, text, className, replacementPrefix, leftLabel, leftLabelHTML, rightLabel, rightLabelHTML}, index) ->
     li = @ol.childNodes[index]
     unless li

--- a/lib/suggestion-list.coffee
+++ b/lib/suggestion-list.coffee
@@ -94,17 +94,8 @@ class SuggestionList
     else
       @destroyOverlay()
       @displayBufferPosition = bufferPosition
-      marker = @suggestionMarker = editor.markBufferPosition(bufferPosition)
-
-      # HACK: When the marker is at the cursor position, it will move with the
-      # cursor, but we want it planted to the buffer position at the beginning
-      # of the prefix. When the marker moves forward, this callback will move it
-      # back to the correct position.
-      marker.onDidChange ({newHeadBufferPosition}) =>
-        if newHeadBufferPosition.column > @displayBufferPosition.column
-          marker.setBufferRange([@displayBufferPosition, @displayBufferPosition])
-
-      @overlayDecoration = editor.decorateMarker(marker, {type: 'overlay', item: this})
+      marker = @suggestionMarker = editor.markBufferRange([bufferPosition, bufferPosition])
+      @overlayDecoration = editor.decorateMarker(marker, {type: 'overlay', item: this, position: 'tail'})
       @addKeyboardInteraction()
       @active = true
 

--- a/lib/suggestion-list.coffee
+++ b/lib/suggestion-list.coffee
@@ -2,6 +2,8 @@
 
 module.exports =
 class SuggestionList
+  wordPrefixRegex: /^[\w-]/
+
   constructor: ->
     @active = false
     @emitter = new Emitter
@@ -73,23 +75,48 @@ class SuggestionList
   isActive: ->
     @active
 
-  show: (editor) =>
-    return if @active
+  show: (editor, options) =>
+    if atom.config.get('autocomplete-plus.suggestionListFollows') is 'Cursor'
+      @showAtCursorPosition(editor, options)
+    else
+      @showAtBeginningOfPrefix(editor, options)
+
+  showAtBeginningOfPrefix: (editor, {prefix}) =>
     return unless editor?
+
+    bufferPosition = editor.getCursorBufferPosition()
+    bufferPosition = bufferPosition.translate([0, -prefix.length]) if @wordPrefixRegex.test(prefix)
+
+    if @active
+      unless bufferPosition.isEqual(@displayBufferPosition)
+        @displayBufferPosition = bufferPosition
+        @suggestionMarker?.setBufferRange([bufferPosition, bufferPosition])
+    else
+      @destroyOverlay()
+      @displayBufferPosition = bufferPosition
+      marker = @suggestionMarker = editor.markBufferPosition(bufferPosition)
+
+      # HACK: When the marker is at the cursor position, it will move with the
+      # cursor, but we want it planted to the buffer position at the beginning
+      # of the prefix. When the marker moves forward, this callback will move it
+      # back to the correct position.
+      marker.onDidChange ({newHeadBufferPosition}) =>
+        if newHeadBufferPosition.column > @displayBufferPosition.column
+          marker.setBufferRange([@displayBufferPosition, @displayBufferPosition])
+
+      @overlayDecoration = editor.decorateMarker(marker, {type: 'overlay', item: this})
+      @addKeyboardInteraction()
+      @active = true
+
+  showAtCursorPosition: (editor) =>
+    return if @active or not editor?
     @destroyOverlay()
 
-    if atom.config.get('autocomplete-plus.suggestionListFollows') is 'Cursor'
-      marker = editor.getLastCursor()?.getMarker()
-      return unless marker?
-    else
-      cursor = editor.getLastCursor()
-      return unless cursor?
-      position = cursor.getBeginningOfCurrentWordBufferPosition()
-      marker = @suggestionMarker = editor.markBufferPosition(position)
-
-    @overlayDecoration = editor.decorateMarker(marker, {type: 'overlay', item: this})
-    @addKeyboardInteraction()
-    @active = true
+    marker = editor.getLastCursor()?.getMarker()
+    if marker?
+      @overlayDecoration = editor.decorateMarker(marker, {type: 'overlay', item: this})
+      @addKeyboardInteraction()
+      @active = true
 
   hide: =>
     return unless @active

--- a/lib/suggestion-list.coffee
+++ b/lib/suggestion-list.coffee
@@ -112,8 +112,7 @@ class SuggestionList
     return if @active or not editor?
     @destroyOverlay()
 
-    marker = editor.getLastCursor()?.getMarker()
-    if marker?
+    if marker = editor.getLastCursor()?.getMarker()
       @overlayDecoration = editor.decorateMarker(marker, {type: 'overlay', item: this})
       @addKeyboardInteraction()
       @active = true

--- a/spec/autocomplete-manager-integration-spec.coffee
+++ b/spec/autocomplete-manager-integration-spec.coffee
@@ -363,7 +363,9 @@ describe 'Autocomplete Manager', ->
           expect(editor.getText()).toBe 'something'
 
     describe "when autocomplete-plus.suggestionListFollows is 'Word'", ->
+      [gutterWidth] = []
       beforeEach ->
+        gutterWidth = editorView.shadowRoot.querySelector('.gutter').offsetWidth
         atom.config.set('autocomplete-plus.suggestionListFollows', 'Word')
 
       afterEach ->
@@ -379,11 +381,92 @@ describe 'Autocomplete Manager', ->
           expect(overlayElement).toExist()
 
           left = editorView.pixelPositionForBufferPosition([0, 2]).left
-          gutterWidth = editorView.shadowRoot.querySelector('.gutter').offsetWidth
-          expect(overlayElement.style.left).toBe "#{left + gutterWidth}px"
+          expect(overlayElement.style.left).toBe "#{gutterWidth + left}px"
 
           atom.commands.dispatch(editorView, 'autocomplete-plus:cancel')
           expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+
+      it "keeps the suggestion list planted at the beginning of the prefix when typing", ->
+        overlayElement = null
+        editor.insertText('x')
+        editor.insertText(' ')
+        waitForAutocomplete()
+
+        runs ->
+          overlayElement = editorView.querySelector('.autocomplete-plus')
+
+          left = editorView.pixelPositionForBufferPosition([0, 2]).left
+          expect(overlayElement.style.left).toBe "#{gutterWidth + left}px"
+
+          editor.insertText('a')
+          waitForAutocomplete()
+
+        runs ->
+          left = editorView.pixelPositionForBufferPosition([0, 2]).left
+          expect(overlayElement.style.left).toBe "#{gutterWidth + left}px"
+
+          editor.insertText('b')
+          waitForAutocomplete()
+
+        runs ->
+          left = editorView.pixelPositionForBufferPosition([0, 2]).left
+          expect(overlayElement.style.left).toBe "#{gutterWidth + left}px"
+
+          editor.backspace()
+          editor.backspace()
+          waitForAutocomplete()
+
+        runs ->
+          left = editorView.pixelPositionForBufferPosition([0, 2]).left
+          expect(overlayElement.style.left).toBe "#{gutterWidth + left}px"
+
+          editor.backspace()
+          waitForAutocomplete()
+
+        runs ->
+          left = editorView.pixelPositionForBufferPosition([0, 0]).left
+          expect(overlayElement.style.left).toBe "#{gutterWidth + left}px"
+
+          editor.insertText(' ')
+          editor.insertText('a')
+          editor.insertText('b')
+          editor.insertText('c')
+          waitForAutocomplete()
+
+        runs ->
+          left = editorView.pixelPositionForBufferPosition([0, 2]).left
+          expect(overlayElement.style.left).toBe "#{gutterWidth + left}px"
+
+      it "when broken by a non-word character, the suggestion list is positioned at the beginning of the new word", ->
+        overlayElement = null
+        editor.insertText('x')
+        editor.insertText(' abc')
+        editor.insertText('d')
+        waitForAutocomplete()
+
+        runs ->
+          overlayElement = editorView.querySelector('.autocomplete-plus')
+
+          left = editorView.pixelPositionForBufferPosition([0, 2]).left
+          expect(overlayElement.style.left).toBe "#{gutterWidth + left}px"
+
+          editor.insertText(' ')
+          editor.insertText('a')
+          editor.insertText('b')
+          waitForAutocomplete()
+
+        runs ->
+          left = editorView.pixelPositionForBufferPosition([0, 7]).left
+          expect(overlayElement.style.left).toBe "#{gutterWidth + left}px"
+
+          editor.backspace()
+          editor.backspace()
+          editor.backspace()
+          waitForAutocomplete()
+
+        runs ->
+          left = editorView.pixelPositionForBufferPosition([0, 2]).left
+          expect(overlayElement.style.left).toBe "#{gutterWidth + left}px"
 
     describe 'accepting suggestions', ->
       beforeEach ->

--- a/spec/autocomplete-manager-integration-spec.coffee
+++ b/spec/autocomplete-manager-integration-spec.coffee
@@ -383,8 +383,17 @@ describe 'Autocomplete Manager', ->
           left = editorView.pixelPositionForBufferPosition([0, 2]).left
           expect(overlayElement.style.left).toBe "#{gutterWidth + left}px"
 
-          atom.commands.dispatch(editorView, 'autocomplete-plus:cancel')
-          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+      it "displays the suggestion list with a negative margin to align the prefix with the word-container", ->
+        spyOn(provider, 'getSuggestions').andCallFake (options) ->
+          [{text: 'ab', leftLabel: 'void'}, {text: 'abc', leftLabel: 'void'}]
+
+        editor.insertText('omghey ab')
+        triggerAutocompletion(editor, false, 'c')
+
+        runs ->
+          suggestionList = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
+          wordContainer = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list .word-container')
+          expect(suggestionList.style['margin-left']).toBe "-#{wordContainer.offsetLeft}px"
 
       it "keeps the suggestion list planted at the beginning of the prefix when typing", ->
         overlayElement = null

--- a/spec/autocomplete-manager-integration-spec.coffee
+++ b/spec/autocomplete-manager-integration-spec.coffee
@@ -379,7 +379,8 @@ describe 'Autocomplete Manager', ->
           expect(overlayElement).toExist()
 
           left = editorView.pixelPositionForBufferPosition([0, 2]).left
-          expect(overlayElement.style.left).toBe "#{left}px"
+          gutterWidth = editorView.shadowRoot.querySelector('.gutter').offsetWidth
+          expect(overlayElement.style.left).toBe "#{left + gutterWidth}px"
 
           atom.commands.dispatch(editorView, 'autocomplete-plus:cancel')
           expect(editorView.querySelector('.autocomplete-plus')).not.toExist()

--- a/spec/autocomplete-manager-integration-spec.coffee
+++ b/spec/autocomplete-manager-integration-spec.coffee
@@ -364,8 +364,7 @@ describe 'Autocomplete Manager', ->
 
     describe "when autocomplete-plus.suggestionListFollows is 'Word'", ->
       requiresGutter = ->
-        parentTag = editorView.querySelector('.autocomplete-plus').parentNode.tagName
-        parentTag is 'ATOM-TEXT-EDITOR'
+        editorView.component?.overlayManager?
 
       pixelLeftForBufferPosition = (bufferPosition) ->
         left = editorView.pixelPositionForBufferPosition(bufferPosition).left

--- a/spec/autocomplete-manager-integration-spec.coffee
+++ b/spec/autocomplete-manager-integration-spec.coffee
@@ -363,6 +363,15 @@ describe 'Autocomplete Manager', ->
           expect(editor.getText()).toBe 'something'
 
     describe "when autocomplete-plus.suggestionListFollows is 'Word'", ->
+      requiresGutter = ->
+        parentTag = editorView.querySelector('.autocomplete-plus').parentNode.tagName
+        parentTag is 'ATOM-TEXT-EDITOR'
+
+      pixelLeftForBufferPosition = (bufferPosition) ->
+        left = editorView.pixelPositionForBufferPosition(bufferPosition).left
+        left = gutterWidth + left if requiresGutter()
+        "#{left}px"
+
       [gutterWidth] = []
       beforeEach ->
         gutterWidth = editorView.shadowRoot.querySelector('.gutter').offsetWidth
@@ -379,9 +388,7 @@ describe 'Autocomplete Manager', ->
           overlayElement = editorView.querySelector('.autocomplete-plus')
 
           expect(overlayElement).toExist()
-
-          left = editorView.pixelPositionForBufferPosition([0, 2]).left
-          expect(overlayElement.style.left).toBe "#{gutterWidth + left}px"
+          expect(overlayElement.style.left).toBe pixelLeftForBufferPosition([0, 2])
 
       it "displays the suggestion list with a negative margin to align the prefix with the word-container", ->
         spyOn(provider, 'getSuggestions').andCallFake (options) ->
@@ -404,37 +411,32 @@ describe 'Autocomplete Manager', ->
         runs ->
           overlayElement = editorView.querySelector('.autocomplete-plus')
 
-          left = editorView.pixelPositionForBufferPosition([0, 2]).left
-          expect(overlayElement.style.left).toBe "#{gutterWidth + left}px"
+          expect(overlayElement.style.left).toBe pixelLeftForBufferPosition([0, 2])
 
           editor.insertText('a')
           waitForAutocomplete()
 
         runs ->
-          left = editorView.pixelPositionForBufferPosition([0, 2]).left
-          expect(overlayElement.style.left).toBe "#{gutterWidth + left}px"
+          expect(overlayElement.style.left).toBe pixelLeftForBufferPosition([0, 2])
 
           editor.insertText('b')
           waitForAutocomplete()
 
         runs ->
-          left = editorView.pixelPositionForBufferPosition([0, 2]).left
-          expect(overlayElement.style.left).toBe "#{gutterWidth + left}px"
+          expect(overlayElement.style.left).toBe pixelLeftForBufferPosition([0, 2])
 
           editor.backspace()
           editor.backspace()
           waitForAutocomplete()
 
         runs ->
-          left = editorView.pixelPositionForBufferPosition([0, 2]).left
-          expect(overlayElement.style.left).toBe "#{gutterWidth + left}px"
+          expect(overlayElement.style.left).toBe pixelLeftForBufferPosition([0, 2])
 
           editor.backspace()
           waitForAutocomplete()
 
         runs ->
-          left = editorView.pixelPositionForBufferPosition([0, 0]).left
-          expect(overlayElement.style.left).toBe "#{gutterWidth + left}px"
+          expect(overlayElement.style.left).toBe pixelLeftForBufferPosition([0, 0])
 
           editor.insertText(' ')
           editor.insertText('a')
@@ -443,8 +445,7 @@ describe 'Autocomplete Manager', ->
           waitForAutocomplete()
 
         runs ->
-          left = editorView.pixelPositionForBufferPosition([0, 2]).left
-          expect(overlayElement.style.left).toBe "#{gutterWidth + left}px"
+          expect(overlayElement.style.left).toBe pixelLeftForBufferPosition([0, 2])
 
       it "when broken by a non-word character, the suggestion list is positioned at the beginning of the new word", ->
         overlayElement = null
@@ -457,7 +458,7 @@ describe 'Autocomplete Manager', ->
           overlayElement = editorView.querySelector('.autocomplete-plus')
 
           left = editorView.pixelPositionForBufferPosition([0, 2]).left
-          expect(overlayElement.style.left).toBe "#{gutterWidth + left}px"
+          expect(overlayElement.style.left).toBe pixelLeftForBufferPosition([0, 2])
 
           editor.insertText(' ')
           editor.insertText('a')
@@ -465,8 +466,7 @@ describe 'Autocomplete Manager', ->
           waitForAutocomplete()
 
         runs ->
-          left = editorView.pixelPositionForBufferPosition([0, 7]).left
-          expect(overlayElement.style.left).toBe "#{gutterWidth + left}px"
+          expect(overlayElement.style.left).toBe pixelLeftForBufferPosition([0, 7])
 
           editor.backspace()
           editor.backspace()
@@ -474,8 +474,7 @@ describe 'Autocomplete Manager', ->
           waitForAutocomplete()
 
         runs ->
-          left = editorView.pixelPositionForBufferPosition([0, 2]).left
-          expect(overlayElement.style.left).toBe "#{gutterWidth + left}px"
+          expect(overlayElement.style.left).toBe pixelLeftForBufferPosition([0, 2])
 
     describe 'accepting suggestions', ->
       beforeEach ->


### PR DESCRIPTION
This will align the replacement with the prefix when `suggestionListFollows` is 'Word'.

![autocomplete-follow-word](https://cloud.githubusercontent.com/assets/69169/7015563/6ccfd8ca-dc8a-11e4-941c-8522cb3c80a3.gif)
