### PR TITLE
Fix prefix bug race condition

### DIFF
--- a/lib/autocomplete-manager.coffee
+++ b/lib/autocomplete-manager.coffee
@@ -169,9 +169,12 @@ class AutocompleteManager
             newSuggestion.rightLabel = suggestion.label if not newSuggestion.rightLabel? and not suggestion.renderLabelAsHtml
             newSuggestion
 
+        cursor = @editor.getLastCursor()
+        replacementPrefix = @getPrefix(@editor, cursor.getBufferPosition()) if cursor?
+
         # FIXME: Cycling through the suggestions again is not ideal :/
         for suggestion in providerSuggestions
-          suggestion.replacementPrefix ?= @getDefaultReplacementPrefix(options.prefix)
+          suggestion.replacementPrefix ?= @getDefaultReplacementPrefix(replacementPrefix ? options.prefix)
           suggestion.provider = provider
           @addManualActivationStrictPrefix(provider, suggestion.replacementPrefix) if activatedManually
 


### PR DESCRIPTION
If a user presses a key and pauses long enough for the autocomplete to initiate (100ms by default) and then presses a key before an async provider returns its value, the 'boldification' of the letters in the autocomplete list will trail behind the actual text. In addition accepting the completion will fail.

This is a fix for that issue.