### PR TITLE
Config API changes for SymbolProvider

### DIFF
--- a/lib/fuzzy-provider.coffee
+++ b/lib/fuzzy-provider.coffee
@@ -161,11 +161,9 @@ class FuzzyProvider
   # Returns an {Array} of strings
   getCompletionsForCursorScope: (scopeDescriptor) ->
     completions = @settingsForScopeDescriptor(scopeDescriptor, 'editor.completions')
-    console.log completions
     resultCompletions = []
     for {value} in completions
       resultCompletions = resultCompletions.concat(value) if Array.isArray(value)
-    console.log resultCompletions
     _.uniq(resultCompletions)
 
   # Public: Clean up, stop listening to events

--- a/lib/fuzzy-provider.coffee
+++ b/lib/fuzzy-provider.coffee
@@ -66,13 +66,13 @@ class FuzzyProvider
   # suggestions, the suggestions will be the only ones that are displayed.
   #
   # Returns an {Array} of Suggestion instances
-  getSuggestions: ({editor, prefix}) =>
+  getSuggestions: ({editor, prefix, scopeDescriptor}) =>
     return unless editor?
 
     # No prefix? Don't autocomplete!
     return unless prefix.trim().length
 
-    suggestions = @findSuggestionsForWord(prefix)
+    suggestions = @findSuggestionsForWord(prefix, scopeDescriptor)
 
     # No suggestions? Don't autocomplete!
     return unless suggestions?.length
@@ -131,12 +131,12 @@ class FuzzyProvider
   # prefix - {String} The prefix
   #
   # Returns an {Array} of Suggestion instances
-  findSuggestionsForWord: (prefix) =>
+  findSuggestionsForWord: (prefix, scopeDescriptor) =>
     return unless @tokenList.getLength() and @editor?
 
     # Merge the scope specific words into the default word list
     tokens = @tokenList.getTokens()
-    tokens = tokens.concat(@getCompletionsForCursorScope())
+    tokens = tokens.concat(@getCompletionsForCursorScope(scopeDescriptor))
 
     words =
       if atom.config.get('autocomplete-plus.strictMatching')
@@ -150,24 +150,23 @@ class FuzzyProvider
     for word in words when word isnt prefix
       # must match the first char!
       continue unless prefix[0].toLowerCase() is word[0].toLowerCase()
-
       results.push {text: word, replacementPrefix: prefix}
-
     results
 
   settingsForScopeDescriptor: (scopeDescriptor, keyPath) ->
-    return [] unless atom?.config? and scopeDescriptor? and keyPath?
-    entries = atom.config.getAll(null, {scope: scopeDescriptor})
-    value for {value} in entries when _.valueForKeyPath(value, keyPath)?
+    atom.config.getAll(keyPath, scope: scopeDescriptor)
 
   # Private: Finds autocompletions in the current syntax scope (e.g. css values)
   #
   # Returns an {Array} of strings
-  getCompletionsForCursorScope: =>
-    cursorScope = @editor.scopeDescriptorForBufferPosition(@editor.getCursorBufferPosition())
-    completions = @settingsForScopeDescriptor(cursorScope?.getScopesArray(), 'editor.completions')
-    completions = completions.map((properties) -> _.valueForKeyPath(properties, 'editor.completions'))
-    return _.uniq(_.flatten(completions))
+  getCompletionsForCursorScope: (scopeDescriptor) ->
+    completions = @settingsForScopeDescriptor(scopeDescriptor, 'editor.completions')
+    console.log completions
+    resultCompletions = []
+    for {value} in completions
+      resultCompletions = resultCompletions.concat(value) if Array.isArray(value)
+    console.log resultCompletions
+    _.uniq(resultCompletions)
 
   # Public: Clean up, stop listening to events
   dispose: =>

--- a/lib/symbol-provider.coffee
+++ b/lib/symbol-provider.coffee
@@ -80,9 +80,15 @@ class SymbolProvider
       for type, options of value
         @config[type] = _.clone(options)
         @config[type].selectors = Selector.create(options.selector) if options.selector?
-        @config[type].selectors ?= []
         @config[type].typePriority ?= 1
-        @config[type].wordRegex ?= @wordRegex
+        @config[type].wordRegex = @wordRegex
+
+        suggestions = @config[type].suggestions
+        if suggestions? and Array.isArray(suggestions)
+          if typeof suggestions[0] is 'string'
+            @config[type].suggestions = ({text, type} for text in suggestions)
+        else
+          @config[type].suggestions = null
 
     return
 

--- a/lib/symbol-provider.coffee
+++ b/lib/symbol-provider.coffee
@@ -146,7 +146,7 @@ class SymbolProvider
     return unless @symbolStore.getLength()
     wordUnderCursor = @wordAtBufferPosition(options)
     @buildConfigIfScopeChanged(options)
-    symbolList = @symbolStore.symbolsForConfig(@config)
+    symbolList = @symbolStore.symbolsForConfig(@config, wordUnderCursor)
 
     words =
       if atom.config.get("autocomplete-plus.strictMatching")

--- a/lib/symbol-provider.coffee
+++ b/lib/symbol-provider.coffee
@@ -23,16 +23,16 @@ class SymbolProvider
   defaultConfig:
     class:
       selector: '.class.name, .inherited-class, .instance.type'
-      priority: 4
+      typePriority: 4
     function:
       selector: '.function.name'
-      priority: 3
+      typePriority: 3
     variable:
       selector: '.variable'
-      priority: 2
+      typePriority: 2
     '':
       selector: '.source'
-      priority: 1
+      typePriority: 1
 
   constructor: ->
     @symbolStore = new SymbolStore(@wordRegex)
@@ -81,7 +81,7 @@ class SymbolProvider
         @config[type] = _.clone(options)
         @config[type].selectors = Selector.create(options.selector) if options.selector?
         @config[type].selectors ?= []
-        @config[type].priority ?= 1
+        @config[type].typePriority ?= 1
         @config[type].wordRegex ?= @wordRegex
 
     return

--- a/lib/symbol-store.coffee
+++ b/lib/symbol-store.coffee
@@ -53,6 +53,7 @@ class Symbol
     unless @type?
       typePriority = 0
       for type, options of config
+        continue unless options.selectors?
         for filePath, {scopeChains} of @metadataByPath
           for scopeChain, __ of scopeChains
             if (!@type or options.typePriority > typePriority) and selectorsMatchScopeChain(options.selectors, scopeChain)
@@ -82,6 +83,8 @@ class SymbolStore
     symbols = []
     for symbolKey, symbol of @symbolMap
       symbols.push(symbol) if symbol.appliesToConfig(config) and not symbol.isSingleInstanceOf(wordUnderCursor)
+    for type, options of config
+      symbols = symbols.concat(options.suggestions) if options.suggestions
     symbols
 
   addToken: (token, editorPath, bufferRow) =>

--- a/lib/symbol-store.coffee
+++ b/lib/symbol-store.coffee
@@ -55,9 +55,9 @@ class Symbol
       for type, options of config
         for filePath, {scopeChains} of @metadataByPath
           for scopeChain, __ of scopeChains
-            if (!@type or options.priority > typePriority) and selectorsMatchScopeChain(options.selectors, scopeChain)
+            if (!@type or options.typePriority > typePriority) and selectorsMatchScopeChain(options.selectors, scopeChain)
               @type = type
-              typePriority = options.priority
+              typePriority = options.typePriority
       @cachedConfig = config
 
     @type?

--- a/spec/fuzzy-provider-spec.coffee
+++ b/spec/fuzzy-provider-spec.coffee
@@ -53,7 +53,7 @@ describe 'FuzzyProvider', ->
       expect(provider.tokenList.getToken('somethingNew')).toBe undefined
       expect(provider.tokenList.getToken('somethingNe')).toBe 'somethingNe'
 
-    it "adds completions from settings", ->
+    it "adds completions from editor.completions", ->
       provider = autocompleteManager.providerManager.fuzzyProvider
       atom.config.set('editor.completions', ['abcd', 'abcde', 'abcdef'], scopeSelector: '.source.js')
 
@@ -66,6 +66,20 @@ describe 'FuzzyProvider', ->
 
       results = provider.getSuggestions({editor, bufferPosition, scopeDescriptor, prefix})
       expect(results[0].text).toBe 'abcd'
+
+    it "adds completions from settings", ->
+      provider = autocompleteManager.providerManager.fuzzyProvider
+      atom.config.set('editor.completions', {builtin: suggestions: ['nope']}, scopeSelector: '.source.js')
+
+      editor.moveToBottom()
+      editor.insertText('ab')
+
+      bufferPosition = editor.getLastCursor().getBufferPosition()
+      scopeDescriptor = editor.getRootScopeDescriptor()
+      prefix = 'ab'
+
+      results = provider.getSuggestions({editor, bufferPosition, scopeDescriptor, prefix})
+      expect(results).toBeUndefined()
 
     # Fixing This Fixes #76
     xit 'adds words to the wordlist with unicode characters', ->

--- a/spec/symbol-provider-spec.coffee
+++ b/spec/symbol-provider-spec.coffee
@@ -224,7 +224,6 @@ describe 'SymbolProvider', ->
       # Using the default config
       editor.setCursorBufferPosition([1, 5])
       suggestions = suggestionsForPrefix(provider, editor, 'in', raw: true)
-      console.log suggestions
       expect(suggestions).toHaveLength 3
       expect(suggestions[0].text).toBe 'invar'
       expect(suggestions[0].type).toBe '' # the js grammar sucks :(
@@ -250,6 +249,23 @@ describe 'SymbolProvider', ->
       expect(suggestions).toHaveLength 4
       expect(suggestions[0].text).toBe 'abcomment'
       expect(suggestions[0].type).toBe 'comment'
+      expect(suggestions[1].text).toBe 'abcd'
+      expect(suggestions[1].type).toBe 'builtin'
+
+  describe "when the legacy completions array is used", ->
+    beforeEach ->
+      editor.setText '''
+        // abcomment
+      '''
+      atom.config.set('editor.completions', ['abcd', 'abcde', 'abcdef'], scopeSelector: '.source.js .comment')
+
+    it "uses the config for the scope under the cursor", ->
+      # Using the comment config
+      editor.setCursorBufferPosition([0, 2])
+      suggestions = suggestionsForPrefix(provider, editor, 'ab', raw: true)
+      expect(suggestions).toHaveLength 4
+      expect(suggestions[0].text).toBe 'abcomment'
+      expect(suggestions[0].type).toBe ''
       expect(suggestions[1].text).toBe 'abcd'
       expect(suggestions[1].type).toBe 'builtin'
 

--- a/spec/symbol-provider-spec.coffee
+++ b/spec/symbol-provider-spec.coffee
@@ -188,7 +188,7 @@ describe 'SymbolProvider', ->
       results = suggestionsForPrefix(provider, editor, 'item')
       expect(results[0]).toBe 'items'
 
-  describe "when the completionConfig changes between scopes", ->
+  describe "when the completions changes between scopes", ->
     beforeEach ->
       editor.setText '''
         // in-a-comment
@@ -203,8 +203,8 @@ describe 'SymbolProvider', ->
         instring:
           selector: '.string'
 
-      atom.config.set('editor.completionConfig', commentConfig, scopeSelector: '.source.js .comment')
-      atom.config.set('editor.completionConfig', stringConfig, scopeSelector: '.source.js .string')
+      atom.config.set('editor.completions', commentConfig, scopeSelector: '.source.js .comment')
+      atom.config.set('editor.completions', stringConfig, scopeSelector: '.source.js .string')
 
     it "uses the config for the scope under the cursor", ->
       # Using the comment config
@@ -228,7 +228,7 @@ describe 'SymbolProvider', ->
       expect(suggestions[0].text).toBe 'invar'
       expect(suggestions[0].type).toBe '' # the js grammar sucks :(
 
-  describe "when the completionConfig contains a list of suggestion strings", ->
+  describe "when the completions contains a list of suggestion strings", ->
     beforeEach ->
       editor.setText '// abcomment'
       commentConfig =
@@ -236,7 +236,7 @@ describe 'SymbolProvider', ->
         builtin:
           suggestions: ['abcd', 'abcde', 'abcdef']
 
-      atom.config.set('editor.completionConfig', commentConfig, scopeSelector: '.source.js .comment')
+      atom.config.set('editor.completions', commentConfig, scopeSelector: '.source.js .comment')
 
     it "adds the suggestions to the results", ->
       # Using the comment config
@@ -248,7 +248,7 @@ describe 'SymbolProvider', ->
       expect(suggestions[1].text).toBe 'abcd'
       expect(suggestions[1].type).toBe 'builtin'
 
-  describe "when the completionConfig contains a list of suggestion objects", ->
+  describe "when the completions contains a list of suggestion objects", ->
     beforeEach ->
       editor.setText '// abcomment'
       commentConfig =
@@ -259,7 +259,7 @@ describe 'SymbolProvider', ->
             {text: 'abcd', rightLabel: 'one', type: 'function'}
             []
           ]
-      atom.config.set('editor.completionConfig', commentConfig, scopeSelector: '.source.js .comment')
+      atom.config.set('editor.completions', commentConfig, scopeSelector: '.source.js .comment')
 
     it "adds the suggestion objects to the results", ->
       # Using the comment config

--- a/spec/symbol-provider-spec.coffee
+++ b/spec/symbol-provider-spec.coffee
@@ -229,6 +229,30 @@ describe 'SymbolProvider', ->
       expect(suggestions[0].text).toBe 'invar'
       expect(suggestions[0].type).toBe '' # the js grammar sucks :(
 
+  describe "when the completionConfig contains a list of completions", ->
+    beforeEach ->
+      editor.setText '''
+        // abcomment
+      '''
+
+      commentConfig =
+        comment:
+          selector: '.comment'
+        builtin:
+          suggestions: ['abcd', 'abcde', 'abcdef']
+
+      atom.config.set('editor.completionConfig', commentConfig, scopeSelector: '.source.js .comment')
+
+    it "uses the config for the scope under the cursor", ->
+      # Using the comment config
+      editor.setCursorBufferPosition([0, 2])
+      suggestions = suggestionsForPrefix(provider, editor, 'ab', raw: true)
+      expect(suggestions).toHaveLength 4
+      expect(suggestions[0].text).toBe 'abcomment'
+      expect(suggestions[0].type).toBe 'comment'
+      expect(suggestions[1].text).toBe 'abcd'
+      expect(suggestions[1].type).toBe 'builtin'
+
   # Fixing This Fixes #76
   xit 'adds words to the wordlist with unicode characters', ->
     expect(provider.symbolStore.indexOf('somēthingNew')).toBeFalsy()

--- a/spec/symbol-provider-spec.coffee
+++ b/spec/symbol-provider-spec.coffee
@@ -228,21 +228,17 @@ describe 'SymbolProvider', ->
       expect(suggestions[0].text).toBe 'invar'
       expect(suggestions[0].type).toBe '' # the js grammar sucks :(
 
-  describe "when the completionConfig contains a list of completions", ->
+  describe "when the completionConfig contains a list of suggestion strings", ->
     beforeEach ->
-      editor.setText '''
-        // abcomment
-      '''
-
+      editor.setText '// abcomment'
       commentConfig =
-        comment:
-          selector: '.comment'
+        comment: selector: '.comment'
         builtin:
           suggestions: ['abcd', 'abcde', 'abcdef']
 
       atom.config.set('editor.completionConfig', commentConfig, scopeSelector: '.source.js .comment')
 
-    it "uses the config for the scope under the cursor", ->
+    it "adds the suggestions to the results", ->
       # Using the comment config
       editor.setCursorBufferPosition([0, 2])
       suggestions = suggestionsForPrefix(provider, editor, 'ab', raw: true)
@@ -252,11 +248,33 @@ describe 'SymbolProvider', ->
       expect(suggestions[1].text).toBe 'abcd'
       expect(suggestions[1].type).toBe 'builtin'
 
+  describe "when the completionConfig contains a list of suggestion objects", ->
+    beforeEach ->
+      editor.setText '// abcomment'
+      commentConfig =
+        comment: selector: '.comment'
+        builtin:
+          suggestions: [
+            {nope: 'nope1', rightLabel: 'will not be added to the suggestions'}
+            {text: 'abcd', rightLabel: 'one', type: 'function'}
+            []
+          ]
+      atom.config.set('editor.completionConfig', commentConfig, scopeSelector: '.source.js .comment')
+
+    it "adds the suggestion objects to the results", ->
+      # Using the comment config
+      editor.setCursorBufferPosition([0, 2])
+      suggestions = suggestionsForPrefix(provider, editor, 'ab', raw: true)
+      expect(suggestions).toHaveLength 2
+      expect(suggestions[0].text).toBe 'abcomment'
+      expect(suggestions[0].type).toBe 'comment'
+      expect(suggestions[1].text).toBe 'abcd'
+      expect(suggestions[1].type).toBe 'function'
+      expect(suggestions[1].rightLabel).toBe 'one'
+
   describe "when the legacy completions array is used", ->
     beforeEach ->
-      editor.setText '''
-        // abcomment
-      '''
+      editor.setText '// abcomment'
       atom.config.set('editor.completions', ['abcd', 'abcde', 'abcdef'], scopeSelector: '.source.js .comment')
 
     it "uses the config for the scope under the cursor", ->

--- a/spec/symbol-store-spec.coffee
+++ b/spec/symbol-store-spec.coffee
@@ -45,7 +45,7 @@ describe 'SymbolStore', ->
       config =
         function:
           selectors: Selector.create('.function')
-          priority: 1
+          typePriority: 1
 
       editor.setText('\n\nabc = -> cats\n\navar = 1')
       expect(store.getLength()).toBe 3
@@ -58,15 +58,15 @@ describe 'SymbolStore', ->
 
     it "updates the symbol types as new tokens come in", ->
       config =
-        class:
-          selectors: Selector.create('.class.name')
-          priority: 4
-        function:
-          selectors: Selector.create('.function')
-          priority: 3
         variable:
           selectors: Selector.create('.variable')
-          priority: 2
+          typePriority: 2
+        function:
+          selectors: Selector.create('.function')
+          typePriority: 3
+        class:
+          selectors: Selector.create('.class.name')
+          typePriority: 4
 
       editor.setText('\n\nabc = -> cats\n\navar = 1')
       symbols = store.symbolsForConfig(config)
@@ -91,7 +91,7 @@ describe 'SymbolStore', ->
       config =
         '':
           selectors: Selector.create('.function')
-          priority: 1
+          typePriority: 1
 
       editor.setText('\n\nabc = -> cats\n\navar = 1')
       symbols = store.symbolsForConfig(config)
@@ -104,7 +104,7 @@ describe 'SymbolStore', ->
       config =
         'function':
           selectors: Selector.create('.function')
-          priority: 1
+          typePriority: 1
 
       editor.setText('\n\nabc = -> cats\n\navar = 1')
       symbols = store.symbolsForConfig(config)
@@ -116,7 +116,7 @@ describe 'SymbolStore', ->
       config =
         'newtype':
           selectors: Selector.create('.function')
-          priority: 1
+          typePriority: 1
 
       editor.setText('\n\nabc = -> cats\n\navar = 1')
       symbols = store.symbolsForConfig(config)


### PR DESCRIPTION
This rounds out the config API for the symbol provider. I am overloading / co-opting `editor.completions` setting to accept the symbol provider config. Language packages will be able to specify a config like this:

```coffee
'.source.coffee':
  editor:
    completions:
      class:
        selector: '.class.name, .inherited-class, .instance.type'
        typePriority: 4
      function:
        selector: '.function.name'
        typePriority: 3
      variable:
        selector: '.variable'
        typePriority: 2
      '':
        selector: '.source'
        typePriority: 1
      builtin:
        suggestions: [
          'one'
          'two'
        ]
```

The old completions array will still work:

```coffee
'.source.coffee':
  editor:
    completions: [
      'one'
      'two'
    ]
```

The `FuzzyProvider` will do what it's always done, and the `SymbolProvider` will add the completions with `type: 'builtin'`.

Note: using the overloaded `editor.completions` setting will not work (specs wont pass) until Atom 191 is out.