### PR TITLE
Fix SymbolProvider to not return the word under cursor

### DIFF
--- a/lib/symbol-store.coffee
+++ b/lib/symbol-store.coffee
@@ -44,6 +44,9 @@ class Symbol
       if getObjectLength(@metadataByPath[editorPath].scopeChains) is 0
         delete @metadataByPath[editorPath]
 
+  isSingleInstanceOf: (word) ->
+    @text is word and @count is 1
+
   appliesToConfig: (config) ->
     @type = null if @cachedConfig isnt config
 
@@ -75,10 +78,10 @@ class SymbolStore
     symbolKey = @getKey(symbolKey)
     @symbolMap[symbolKey]
 
-  symbolsForConfig: (config) ->
+  symbolsForConfig: (config, wordUnderCursor) ->
     symbols = []
     for symbolKey, symbol of @symbolMap
-      symbols.push(symbol) if symbol.appliesToConfig(config)
+      symbols.push(symbol) if symbol.appliesToConfig(config) and not symbol.isSingleInstanceOf(wordUnderCursor)
     symbols
 
   addToken: (token, editorPath, bufferRow) =>

--- a/spec/symbol-provider-spec.coffee
+++ b/spec/symbol-provider-spec.coffee
@@ -81,6 +81,30 @@ describe 'SymbolProvider', ->
     expect(suggestionsForPrefix(provider, editor, 'anew')).toContain 'aNewFunctio'
     expect(suggestionsForPrefix(provider, editor, 'anew')).not.toContain 'aNewFunction'
 
+  it "does not return the word under the cursor when there is only a prefix", ->
+    editor.moveToBottom()
+    editor.insertText('qu')
+    expect(suggestionsForPrefix(provider, editor, 'qu')).not.toContain 'qu'
+
+    editor.insertText(' qu')
+    expect(suggestionsForPrefix(provider, editor, 'qu')).toContain 'qu'
+
+  it "does not return the word under the cursor when there is a suffix only one instance of the word", ->
+    editor.moveToBottom()
+    editor.insertText('catscats')
+    editor.moveToBeginningOfLine()
+    editor.insertText('omg')
+    expect(suggestionsForPrefix(provider, editor, 'omg')).not.toContain 'omg'
+    expect(suggestionsForPrefix(provider, editor, 'omg')).not.toContain 'omgcatscats'
+
+  it "returns the word under the cursor when there is a suffix and there are multiple instances of the word", ->
+    editor.moveToBottom()
+    editor.insertText('icksort')
+    editor.moveToBeginningOfLine()
+    editor.insertText('qu')
+    expect(suggestionsForPrefix(provider, editor, 'qu')).not.toContain 'qu'
+    expect(suggestionsForPrefix(provider, editor, 'qu')).toContain 'quicksort'
+
   it "correctly tracks the buffer row associated with symbols as they change", ->
     editor.setText('')
     advanceClock(provider.changeUpdateDelay)


### PR DESCRIPTION
It would return the word under the cursor in the suggestion list:

![autocomplete-word-under-cursor](https://cloud.githubusercontent.com/assets/69169/7078917/006174d2-ded3-11e4-9215-e047d5ecb5ad.gif)

