### PR TITLE
Use core:move-up/down rather than custom select-prev/next commands

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -28,13 +28,6 @@ module.exports =
       default: 'tab'
       enum: ['tab', 'enter', 'tab and enter']
       order: 4
-    navigateCompletions:
-      title: 'Keymap For Navigating The Suggestion List'
-      description: 'You should use the keys indicated here to select suggestions in the suggestion list (moving up or down).'
-      type: 'string'
-      default: 'up,down'
-      enum: ['up,down', 'ctrl-p,ctrl-n']
-      order: 5
     fileBlacklist:
       title: 'File Blacklist'
       description: 'Suggestions will not be provided for files matching this list.'
@@ -42,7 +35,7 @@ module.exports =
       default: ['.*']
       items:
         type: 'string'
-      order: 6
+      order: 5
     scopeBlacklist:
       title: 'Scope Blacklist'
       description: 'Suggestions will not be provided for scopes matching this list. See: https://atom.io/docs/latest/advanced/scopes-and-scope-descriptors'
@@ -50,55 +43,55 @@ module.exports =
       default: []
       items:
         type: 'string'
-      order: 7
+      order: 6
     includeCompletionsFromAllBuffers:
       title: 'Include Completions From All Buffers'
       description: 'For grammars with no registered provider(s), FuzzyProvider will include completions from all buffers, instead of just the buffer you are currently editing.'
       type: 'boolean'
       default: false
-      order: 8
+      order: 7
     strictMatching:
       title: 'Use Strict Matching For Built-In Provider'
       description: 'Fuzzy searching is performed if this is disabled; if it is enabled, suggestions must begin with the prefix from the current word.'
       type: 'boolean'
       default: false
-      order: 9
+      order: 8
     minimumWordLength:
       description: "Only autocomplete when you've typed at least this many characters."
       type: 'integer'
       default: 1
-      order: 10
+      order: 9
     enableBuiltinProvider:
       title: 'Enable Built-In Provider'
       description: 'The package comes with a built-in provider that will provide suggestions using the words in your current buffer or all open buffers. You will get better suggestions by installing additional autocomplete+ providers. To stop using the built-in provider, disable this option.'
       type: 'boolean'
       default: true
-      order: 11
+      order: 10
     builtinProviderBlacklist:
       title: 'Built-In Provider Blacklist'
       description: 'Don\'t use the built-in provider for these selector(s).'
       type: 'string'
       default: '.source.gfm'
-      order: 12
+      order: 11
     backspaceTriggersAutocomplete:
       title: 'Allow Backspace To Trigger Autocomplete'
       description: 'If enabled, typing `backspace` will show the suggestion list if suggestions are available. If disabled, suggestions will not be shown while backspacing.'
       type: 'boolean'
       default: true
-      order: 13
+      order: 12
     suggestionListFollows:
       title: 'Suggestions List Follows'
       description: 'With "Cursor" the suggestion list appears at the cursor\'s position. With "Word" it appears at the beginning of the word that\'s being completed.'
       type: 'string'
       default: 'Word'
       enum: ['Word', 'Cursor']
-      order: 14
+      order: 13
     defaultProvider:
       description: 'Using the Symbol provider is experimental. You must reload Atom to use a new provider after changing this option.'
       type: 'string'
       default: 'Fuzzy'
       enum: ['Fuzzy', 'Symbol']
-      order: 15
+      order: 14
     suppressActivationForEditorClasses:
       title: 'Suppress Activation For Editor Classes'
       description: 'Don\'t auto-activate when any of these classes are present in the editor.'
@@ -106,7 +99,7 @@ module.exports =
       default: ['vim-mode.command-mode', 'vim-mode.visual-mode', 'vim-mode.operator-pending-mode']
       items:
         type: 'string'
-      order: 16
+      order: 15
 
   # Public: Creates AutocompleteManager instances for all active and future editors (soon, just a single AutocompleteManager)
   activate: ->

--- a/spec/autocomplete-manager-integration-spec.coffee
+++ b/spec/autocomplete-manager-integration-spec.coffee
@@ -861,9 +861,6 @@ describe 'Autocomplete Manager', ->
           waitForAutocomplete()
 
         runs ->
-          waitForAutocomplete()
-
-        runs ->
           autocomplete = editorView.querySelector('.autocomplete-plus')
           expect(autocomplete).toExist()
 

--- a/spec/autocomplete-manager-integration-spec.coffee
+++ b/spec/autocomplete-manager-integration-spec.coffee
@@ -833,8 +833,7 @@ describe 'Autocomplete Manager', ->
           expect(items[2]).not.toHaveClass('selected')
 
           # Select previous item
-          suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
-          atom.commands.dispatch(suggestionListView, 'autocomplete-plus:select-previous')
+          atom.commands.dispatch(editorView, 'core:move-up')
 
           items = editorView.querySelectorAll('.autocomplete-plus li')
           expect(items[0]).not.toHaveClass('selected')
@@ -852,8 +851,7 @@ describe 'Autocomplete Manager', ->
 
         runs ->
           # two items displayed, should not close
-          key = atom.keymaps.constructor.buildKeydownEvent('up', {target: document.activeElement})
-          atom.keymaps.handleKeyboardEvent(key)
+          atom.commands.dispatch(editorView, 'core:move-up')
           advanceClock(1)
 
           autocomplete = editorView.querySelector('.autocomplete-plus')
@@ -863,9 +861,14 @@ describe 'Autocomplete Manager', ->
           waitForAutocomplete()
 
         runs ->
+          waitForAutocomplete()
+
+        runs ->
+          autocomplete = editorView.querySelector('.autocomplete-plus')
+          expect(autocomplete).toExist()
+
           # one item displayed, should close
-          key = atom.keymaps.constructor.buildKeydownEvent('up', {target: document.activeElement})
-          atom.keymaps.handleKeyboardEvent(key)
+          atom.commands.dispatch(editorView, 'core:move-up')
           advanceClock(1)
 
           autocomplete = editorView.querySelector('.autocomplete-plus')
@@ -886,25 +889,14 @@ describe 'Autocomplete Manager', ->
           waitForAutocomplete()
 
         runs ->
-          key = atom.keymaps.constructor.buildKeydownEvent('up', {target: document.activeElement})
-          atom.keymaps.handleKeyboardEvent(key)
+          autocomplete = editorView.querySelector('.autocomplete-plus')
+          expect(autocomplete).toExist()
+
+          atom.commands.dispatch(editorView, 'core:move-up')
           advanceClock(1)
 
           autocomplete = editorView.querySelector('.autocomplete-plus')
           expect(autocomplete).toExist()
-
-      it 'closes the autocomplete when up arrow while up,down navigation not selected', ->
-        atom.config.set('autocomplete-plus.navigateCompletions', 'ctrl-p,ctrl-n')
-        triggerAutocompletion(editor, false, 'a')
-
-        runs ->
-          # Accept suggestion
-          key = atom.keymaps.constructor.buildKeydownEvent('up', {target: document.activeElement})
-          atom.keymaps.handleKeyboardEvent(key)
-          advanceClock(1)
-
-          autocomplete = editorView.querySelector('.autocomplete-plus')
-          expect(autocomplete).not.toExist()
 
     describe 'select-next event', ->
       it 'selects the next item in the list', ->
@@ -917,9 +909,7 @@ describe 'Autocomplete Manager', ->
           expect(items[2]).not.toHaveClass('selected')
 
           # Select next item
-
-          suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
-          atom.commands.dispatch(suggestionListView, 'autocomplete-plus:select-next')
+          atom.commands.dispatch(editorView, 'core:move-down')
 
           items = editorView.querySelectorAll('.autocomplete-plus li')
           expect(items[0]).not.toHaveClass('selected')
@@ -941,13 +931,13 @@ describe 'Autocomplete Manager', ->
           suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
           items = editorView.querySelectorAll('.autocomplete-plus li')
 
-          atom.commands.dispatch(suggestionListView, 'autocomplete-plus:select-next')
+          atom.commands.dispatch(suggestionListView, 'core:move-down')
           expect(items[1]).toHaveClass('selected')
 
-          atom.commands.dispatch(suggestionListView, 'autocomplete-plus:select-next')
+          atom.commands.dispatch(suggestionListView, 'core:move-down')
           expect(items[2]).toHaveClass('selected')
 
-          atom.commands.dispatch(suggestionListView, 'autocomplete-plus:select-next')
+          atom.commands.dispatch(suggestionListView, 'core:move-down')
           expect(items[0]).toHaveClass('selected')
 
     describe "label rendering", ->


### PR DESCRIPTION
I'm not sure why custom commands were being used to navigate the suggestion list. I think ideally, it should work with whatever you have mapped to core:move-up/down. 