### PR TITLE
Suggestion descriptions

### DIFF
--- a/lib/suggestion-list-element.coffee
+++ b/lib/suggestion-list-element.coffee
@@ -134,11 +134,11 @@ class SuggestionListElement extends HTMLElement
     @mainDiv.appendChild(@ol)
 
     @docDiv = document.createElement('div')
-    @docDiv.className = 'docstring'
+    @docDiv.className = 'suggestion-description'
     ruler = document.createElement('hr')
     @docDiv.appendChild(ruler)
     @docSpan = document.createElement('span')
-    @docSpan.className = 'docstring'
+    @docSpan.className = 'suggestion-description'
     @docDiv.appendChild(@docSpan)
 
     @mainDiv.appendChild(@docDiv)

--- a/lib/suggestion-list-element.coffee
+++ b/lib/suggestion-list-element.coffee
@@ -68,10 +68,19 @@ class SuggestionListElement extends HTMLElement
       event.stopPropagation()
       @confirmSelection()
 
+  updateDoc: ->
+    if @visibleItems()[@selectedIndex]['description']?
+      @docDiv.style.display = 'block'
+      @docSpan.textContent = @visibleItems()[@selectedIndex]['description']
+    else
+      @docDiv.style.display = 'none'
+
   itemsChanged: ->
     @selectedIndex = 0
     atom.views.pollAfterNextUpdate?()
-    atom.views.updateDocument => @renderItems()
+    atom.views.updateDocument =>
+      @renderItems()
+      @updateDoc()
 
   addActiveClassToEditor: ->
     editorElement = atom.views.getView(atom.workspace.getActiveTextEditor())
@@ -96,6 +105,7 @@ class SuggestionListElement extends HTMLElement
   setSelectedIndex: (index) ->
     @selectedIndex = index
     @renderItems()
+    @updateDoc()
 
   visibleItems: ->
     @model?.items?.slice(0, @maxItems)
@@ -117,9 +127,22 @@ class SuggestionListElement extends HTMLElement
       @model.cancel()
 
   renderList: ->
+    @mainDiv = document.createElement('div')
+
     @ol = document.createElement('ol')
-    @appendChild(@ol)
     @ol.className = 'list-group'
+    @mainDiv.appendChild(@ol)
+
+    @docDiv = document.createElement('div')
+    @docDiv.className = 'docstring'
+    ruler = document.createElement('hr')
+    @docDiv.appendChild(ruler)
+    @docSpan = document.createElement('span')
+    @docSpan.className = 'docstring'
+    @docDiv.appendChild(@docSpan)
+
+    @mainDiv.appendChild(@docDiv)
+    @appendChild(@mainDiv)
 
   calculateMaxListHeight: ->
     li = document.createElement('li')

--- a/lib/suggestion-list-element.coffee
+++ b/lib/suggestion-list-element.coffee
@@ -16,6 +16,7 @@ ListTemplate = """
   </div>
   <div class="suggestion-description">
     <span class="suggestion-description-content"></span>
+    <a class="suggestion-description-more-link" href="#">More..</a>
   </div>
 """
 
@@ -82,6 +83,12 @@ class SuggestionListElement extends HTMLElement
     if item.description? and item.description.length > 0
       @descriptionContainer.style.display = 'block'
       @descriptionContent.textContent = item.description
+      if item.descriptionMoreURL? and item.descriptionMoreURL.length?
+        @descriptionMoreLink.style.display = 'inline'
+        @descriptionMoreLink.setAttribute('href', item.descriptionMoreURL)
+      else
+        @descriptionMoreLink.style.display = 'none'
+        @descriptionMoreLink.setAttribute('href', '#')
     else
       @descriptionContainer.style.display = 'none'
 
@@ -142,6 +149,7 @@ class SuggestionListElement extends HTMLElement
     @scroller = @querySelector('.suggestion-list-scroller')
     @descriptionContainer = @querySelector('.suggestion-description')
     @descriptionContent = @querySelector('.suggestion-description-content')
+    @descriptionMoreLink = @querySelector('.suggestion-description-more-link')
 
   calculateMaxListHeight: ->
     li = document.createElement('li')

--- a/lib/suggestion-list-element.coffee
+++ b/lib/suggestion-list-element.coffee
@@ -11,10 +11,11 @@ ItemTemplate = """
 """
 
 ListTemplate = """
-  <ol class="list-group"></ol>
+  <div class="suggestion-list-scroller">
+    <ol class="list-group"></ol>
+  </div>
   <div class="suggestion-description">
-    <hr />
-    <span class="suggestion-description"></span>
+    <span class="suggestion-description-content"></span>
   </div>
 """
 
@@ -76,19 +77,20 @@ class SuggestionListElement extends HTMLElement
       event.stopPropagation()
       @confirmSelection()
 
-  updateDoc: ->
-    if @visibleItems()[@selectedIndex]['description']? and @visibleItems()[@selectedIndex]['description'].length > 0
-      @docDiv.style.display = 'block'
-      @docSpan.textContent = @visibleItems()[@selectedIndex]['description']
+  updateDescription: ->
+    item = @visibleItems()[@selectedIndex]
+    if item.description? and item.description.length > 0
+      @descriptionContainer.style.display = 'block'
+      @descriptionContent.textContent = item.description
     else
-      @docDiv.style.display = 'none'
+      @descriptionContainer.style.display = 'none'
 
   itemsChanged: ->
     @selectedIndex = 0
     atom.views.pollAfterNextUpdate?()
     atom.views.updateDocument =>
       @renderItems()
-      @updateDoc()
+      @updateDescription()
 
   addActiveClassToEditor: ->
     editorElement = atom.views.getView(atom.workspace.getActiveTextEditor())
@@ -113,7 +115,7 @@ class SuggestionListElement extends HTMLElement
   setSelectedIndex: (index) ->
     @selectedIndex = index
     @renderItems()
-    @updateDoc()
+    @updateDescription()
 
   visibleItems: ->
     @model?.items?.slice(0, @maxItems)
@@ -135,15 +137,11 @@ class SuggestionListElement extends HTMLElement
       @model.cancel()
 
   renderList: ->
-    @mainDiv = document.createElement('div')
-    @mainDiv.innerHTML = ListTemplate
-
-    @ol = @mainDiv.getElementsByClassName("list-group")[0]
-
-    @docDiv = @mainDiv.querySelector('div.suggestion-description')
-    @docSpan = @mainDiv.querySelector('span.suggestion-description')
-
-    @appendChild(@mainDiv)
+    @innerHTML = ListTemplate
+    @ol = @querySelector('.list-group')
+    @scroller = @querySelector('.suggestion-list-scroller')
+    @descriptionContainer = @querySelector('.suggestion-description')
+    @descriptionContent = @querySelector('.suggestion-description-content')
 
   calculateMaxListHeight: ->
     li = document.createElement('li')
@@ -151,7 +149,7 @@ class SuggestionListElement extends HTMLElement
     @ol.appendChild(li)
     itemHeight = li.offsetHeight
     paddingHeight = parseInt(getComputedStyle(this)['padding-top']) + parseInt(getComputedStyle(this)['padding-bottom']) ? 0
-    @style['max-height'] = "#{@maxVisibleSuggestions * itemHeight + paddingHeight}px"
+    @scroller.style['max-height'] = "#{@maxVisibleSuggestions * itemHeight + paddingHeight}px"
     li.remove()
 
   renderItems: ->

--- a/lib/suggestion-list-element.coffee
+++ b/lib/suggestion-list-element.coffee
@@ -69,14 +69,21 @@ class SuggestionListElement extends HTMLElement
   registerMouseHandling: ->
     @onmousewheel = (event) -> event.stopPropagation()
     @onmousedown = (event) ->
-      item = event.target
-      item = item.parentNode while not (item.dataset?.index) and item isnt this
-      @selectedIndex = item.dataset?.index
-      event.stopPropagation()
+      item = @findItem(event)
+      if item?.dataset.index?
+        @selectedIndex = item.dataset.index
+        event.stopPropagation()
 
     @onmouseup = (event) ->
-      event.stopPropagation()
-      @confirmSelection()
+      item = @findItem(event)
+      if item?.dataset.index?
+        event.stopPropagation()
+        @confirmSelection()
+
+  findItem: (event) ->
+    item = event.target
+    item = item.parentNode while item.tagName isnt 'LI' and item isnt this
+    item if item.tagName is 'LI'
 
   updateDescription: ->
     item = @visibleItems()[@selectedIndex]

--- a/lib/suggestion-list-element.coffee
+++ b/lib/suggestion-list-element.coffee
@@ -10,6 +10,14 @@ ItemTemplate = """
   </span>
 """
 
+ListTemplate = """
+  <ol class="list-group"></ol>
+  <div class="suggestion-description">
+    <hr />
+    <span class="suggestion-description"></span>
+  </div>
+"""
+
 IconTemplate = '<i class="icon"></i>'
 
 DefaultSuggestionTypeIconHTML =
@@ -69,7 +77,7 @@ class SuggestionListElement extends HTMLElement
       @confirmSelection()
 
   updateDoc: ->
-    if @visibleItems()[@selectedIndex]['description']?
+    if @visibleItems()[@selectedIndex]['description']? and @visibleItems()[@selectedIndex]['description'].length > 0
       @docDiv.style.display = 'block'
       @docSpan.textContent = @visibleItems()[@selectedIndex]['description']
     else
@@ -128,20 +136,13 @@ class SuggestionListElement extends HTMLElement
 
   renderList: ->
     @mainDiv = document.createElement('div')
+    @mainDiv.innerHTML = ListTemplate
 
-    @ol = document.createElement('ol')
-    @ol.className = 'list-group'
-    @mainDiv.appendChild(@ol)
+    @ol = @mainDiv.getElementsByClassName("list-group")[0]
 
-    @docDiv = document.createElement('div')
-    @docDiv.className = 'suggestion-description'
-    ruler = document.createElement('hr')
-    @docDiv.appendChild(ruler)
-    @docSpan = document.createElement('span')
-    @docSpan.className = 'suggestion-description'
-    @docDiv.appendChild(@docSpan)
+    @docDiv = @mainDiv.querySelector('div.suggestion-description')
+    @docSpan = @mainDiv.querySelector('span.suggestion-description')
 
-    @mainDiv.appendChild(@docDiv)
     @appendChild(@mainDiv)
 
   calculateMaxListHeight: ->

--- a/spec/autocomplete-manager-integration-spec.coffee
+++ b/spec/autocomplete-manager-integration-spec.coffee
@@ -1098,6 +1098,46 @@ describe 'Autocomplete Manager', ->
             label = editorView.querySelector('.autocomplete-plus li .left-label .something')
             expect(label).toHaveText('sometext')
 
+    describe 'when clicking in the suggestion list', ->
+      beforeEach ->
+        spyOn(provider, 'getSuggestions').andCallFake ->
+          list = ['ab', 'abc', 'abcd', 'abcde']
+          ({text, description: "#{text} yeah ok"} for text in list)
+
+      it 'will select the item and confirm the selection', ->
+        triggerAutocompletion(editor, true, 'a')
+
+        runs ->
+          # Get the second item
+          item = editorView.querySelectorAll('.autocomplete-plus li')[1]
+
+          # Click the item, expect list to be hidden and text to be added
+          mouse = document.createEvent('MouseEvents')
+          mouse.initMouseEvent('mousedown', true, true, window)
+          item.dispatchEvent(mouse)
+          mouse = document.createEvent('MouseEvents')
+          mouse.initMouseEvent('mouseup', true, true, window)
+          item.dispatchEvent(mouse)
+
+          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+          expect(editor.getBuffer().getLastLine()).toEqual(item.textContent.trim())
+
+      it 'will not close the list when the description is clicked', ->
+        triggerAutocompletion(editor, true, 'a')
+
+        runs ->
+          description = editorView.querySelector('.autocomplete-plus .suggestion-description-content')
+
+          # Click the description, expect list to still show
+          mouse = document.createEvent('MouseEvents')
+          mouse.initMouseEvent('mousedown', true, true, window)
+          description.dispatchEvent(mouse)
+          mouse = document.createEvent('MouseEvents')
+          mouse.initMouseEvent('mouseup', true, true, window)
+          description.dispatchEvent(mouse)
+
+          expect(editorView.querySelector('.autocomplete-plus')).toExist()
+
   describe 'when opening a file without a path', ->
     beforeEach ->
       waitsForPromise ->
@@ -1329,26 +1369,6 @@ describe 'Autocomplete Manager', ->
 
         runs ->
           expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-
-    describe 'when a suggestion is clicked', ->
-      it 'should select the item and confirm the selection', ->
-        triggerAutocompletion(editor, true, 'a')
-
-        runs ->
-          # Get the second item
-          item = editorView.querySelectorAll('.autocomplete-plus li')[1]
-
-          # Click the item, expect list to be hidden and
-          # text to be added
-          mouse = document.createEvent('MouseEvents')
-          mouse.initMouseEvent('mousedown', true, true, window)
-          item.dispatchEvent(mouse)
-          mouse = document.createEvent('MouseEvents')
-          mouse.initMouseEvent('mouseup', true, true, window)
-          item.dispatchEvent(mouse)
-
-          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
-          expect(editor.getBuffer().getLastLine()).toEqual(item.textContent.trim())
 
     describe '.cancel()', ->
       it 'unbinds autocomplete event handlers for move-up and move-down', ->

--- a/spec/autocomplete-manager-integration-spec.coffee
+++ b/spec/autocomplete-manager-integration-spec.coffee
@@ -209,14 +209,36 @@ describe 'Autocomplete Manager', ->
       beforeEach ->
         atom.config.set('autocomplete-plus.maxVisibleSuggestions', 2)
 
-      it "only shows the maxVisibleSuggestions in the suggestion popup", ->
-        triggerAutocompletion(editor, true, 'a')
+      describe "when a suggestion description is not specified", ->
+        it "only shows the maxVisibleSuggestions in the suggestion popup", ->
+          triggerAutocompletion(editor, true, 'a')
 
-        runs ->
-          expect(editorView.querySelector('.autocomplete-plus')).toExist()
-          itemHeight = parseInt(getComputedStyle(editorView.querySelector('.autocomplete-plus li')).height)
-          expect(editorView.querySelectorAll('.autocomplete-plus li')).toHaveLength 4
-          expect(editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list .suggestion-list-scroller').style['max-height']).toBe("#{2 * itemHeight}px")
+          runs ->
+            expect(editorView.querySelector('.autocomplete-plus')).toExist()
+            itemHeight = parseInt(getComputedStyle(editorView.querySelector('.autocomplete-plus li')).height)
+            expect(editorView.querySelectorAll('.autocomplete-plus li')).toHaveLength 4
+
+            suggestionList = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
+            expect(suggestionList.offsetHeight).toBe(2 * itemHeight)
+            expect(suggestionList.querySelector('.suggestion-list-scroller').style['max-height']).toBe("#{2 * itemHeight}px")
+
+      describe "when a suggestion description is specified", ->
+        beforeEach ->
+          spyOn(provider, 'getSuggestions').andCallFake ->
+            list = ['ab', 'abc', 'abcd', 'abcde']
+            ({text, description: "#{text} yeah ok"} for text in list)
+
+        it "shows the maxVisibleSuggestions in the suggestion popup, but with extra height for the description", ->
+          triggerAutocompletion(editor, true, 'a')
+
+          runs ->
+            expect(editorView.querySelector('.autocomplete-plus')).toExist()
+            itemHeight = parseInt(getComputedStyle(editorView.querySelector('.autocomplete-plus li')).height)
+            expect(editorView.querySelectorAll('.autocomplete-plus li')).toHaveLength 4
+
+            suggestionList = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
+            expect(suggestionList.offsetHeight).toBe(3 * itemHeight)
+            expect(suggestionList.querySelector('.suggestion-list-scroller').style['max-height']).toBe("#{2 * itemHeight}px")
 
     describe "when match.snippet is used", ->
       beforeEach ->

--- a/spec/autocomplete-manager-integration-spec.coffee
+++ b/spec/autocomplete-manager-integration-spec.coffee
@@ -216,7 +216,7 @@ describe 'Autocomplete Manager', ->
           expect(editorView.querySelector('.autocomplete-plus')).toExist()
           itemHeight = parseInt(getComputedStyle(editorView.querySelector('.autocomplete-plus li')).height)
           expect(editorView.querySelectorAll('.autocomplete-plus li')).toHaveLength 4
-          expect(editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list').style['max-height']).toBe("#{2 * itemHeight}px")
+          expect(editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list .suggestion-list-scroller').style['max-height']).toBe("#{2 * itemHeight}px")
 
     describe "when match.snippet is used", ->
       beforeEach ->

--- a/spec/provider-api-spec.coffee
+++ b/spec/provider-api-spec.coffee
@@ -83,6 +83,7 @@ describe 'Provider API', ->
             text: 'ohai',
             replacementPrefix: 'o',
             rightLabelHTML: '<span style="color: red">ohai</span>',
+            description: 'There be documentation'
           ]
       registration = atom.packages.serviceHub.provide('autocomplete.provider', '2.0.0', testProvider)
 
@@ -92,3 +93,4 @@ describe 'Provider API', ->
         suggestionListView = atom.views.getView(autocompleteManager.suggestionList)
         expect(suggestionListView.querySelector('li .right-label')).toHaveHtml('<span style="color: red">ohai</span>')
         expect(suggestionListView.querySelector('span.word')).toHaveText('ohai')
+        expect(suggestionListView.querySelector('span.docstring').toHaveText('There be documentation'))

--- a/spec/provider-api-spec.coffee
+++ b/spec/provider-api-spec.coffee
@@ -93,4 +93,4 @@ describe 'Provider API', ->
         suggestionListView = atom.views.getView(autocompleteManager.suggestionList)
         expect(suggestionListView.querySelector('li .right-label')).toHaveHtml('<span style="color: red">ohai</span>')
         expect(suggestionListView.querySelector('span.word')).toHaveText('ohai')
-        expect(suggestionListView.querySelector('span.docstring').toHaveText('There be documentation'))
+        expect(suggestionListView.querySelector('span.suggestion-description').toHaveText('There be documentation'))

--- a/spec/provider-api-spec.coffee
+++ b/spec/provider-api-spec.coffee
@@ -94,3 +94,28 @@ describe 'Provider API', ->
         expect(suggestionListView.querySelector('li .right-label')).toHaveHtml('<span style="color: red">ohai</span>')
         expect(suggestionListView.querySelector('.word')).toHaveText('ohai')
         expect(suggestionListView.querySelector('.suggestion-description-content')).toHaveText('There be documentation')
+        expect(suggestionListView.querySelector('.suggestion-description-more-link').style.display).toBe 'none'
+
+    it 'correctly displays the suggestion description and More link', ->
+      testProvider =
+        selector: '.source.js, .source.coffee'
+        getSuggestions: (options) ->
+          [
+            text: 'ohai',
+            replacementPrefix: 'o',
+            rightLabelHTML: '<span style="color: red">ohai</span>',
+            description: 'There be documentation'
+            descriptionMoreURL: 'http://google.com'
+          ]
+      registration = atom.packages.serviceHub.provide('autocomplete.provider', '2.0.0', testProvider)
+
+      triggerAutocompletion(editor, true, 'o')
+
+      runs ->
+        suggestionListView = atom.views.getView(autocompleteManager.suggestionList)
+        content = suggestionListView.querySelector('.suggestion-description-content')
+        moreLink = suggestionListView.querySelector('.suggestion-description-more-link')
+        expect(content).toHaveText('There be documentation')
+        expect(moreLink).toHaveText('More..')
+        expect(moreLink.style.display).toBe 'inline'
+        expect(moreLink.getAttribute('href')).toBe 'http://google.com'

--- a/spec/provider-api-spec.coffee
+++ b/spec/provider-api-spec.coffee
@@ -93,4 +93,4 @@ describe 'Provider API', ->
         suggestionListView = atom.views.getView(autocompleteManager.suggestionList)
         expect(suggestionListView.querySelector('li .right-label')).toHaveHtml('<span style="color: red">ohai</span>')
         expect(suggestionListView.querySelector('span.word')).toHaveText('ohai')
-        expect(suggestionListView.querySelector('span.suggestion-description').toHaveText('There be documentation'))
+        expect(suggestionListView.querySelector('span.suggestion-description')).toHaveText('There be documentation')

--- a/spec/provider-api-spec.coffee
+++ b/spec/provider-api-spec.coffee
@@ -92,5 +92,5 @@ describe 'Provider API', ->
       runs ->
         suggestionListView = atom.views.getView(autocompleteManager.suggestionList)
         expect(suggestionListView.querySelector('li .right-label')).toHaveHtml('<span style="color: red">ohai</span>')
-        expect(suggestionListView.querySelector('span.word')).toHaveText('ohai')
-        expect(suggestionListView.querySelector('span.suggestion-description')).toHaveText('There be documentation')
+        expect(suggestionListView.querySelector('.word')).toHaveText('ohai')
+        expect(suggestionListView.querySelector('.suggestion-description-content')).toHaveText('There be documentation')

--- a/styles/autocomplete.less
+++ b/styles/autocomplete.less
@@ -39,6 +39,12 @@ autocomplete-suggestion-list.select-list.popover-list {
     font-family: @font-family;
   }
 
+  .suggestion-description-more-link {
+    font-size: @font-size + 1px;
+    font-family: @font-family;
+    color: @text-color-info;
+  }
+
   input {
     position: absolute;
     opacity: 0.00;

--- a/styles/autocomplete.less
+++ b/styles/autocomplete.less
@@ -30,7 +30,7 @@ autocomplete-suggestion-list.select-list.popover-list {
     min-height: @row-line-height;
     line-height: 1.3;
 
-    background: darken(@overlay-background-color, 5%);
+    background: darken(@overlay-background-color, 4%);
     border-radius: 0 0 @component-border-radius @component-border-radius;
   }
 

--- a/styles/autocomplete.less
+++ b/styles/autocomplete.less
@@ -1,8 +1,9 @@
 @import "ui-variables";
 @import "syntax-variables";
 
+@font-size-small: .9em;
 @type-icon-font-size: 1em;
-@type-letter-icon-font-size: .9em;
+@type-letter-icon-font-size: @font-size-small;
 @row-line-height: 2em;
 @item-padding: .75em;
 @item-side-padding: .6em;
@@ -15,21 +16,29 @@ autocomplete-suggestion-list.select-list.popover-list {
   width: auto;
   display: inline-block;
   min-width: 200px;
-  overflow-y: auto;
   padding: 0;
   max-width: 700px;
+
+  .suggestion-list-scroller {
+    overflow-y: auto;
+  }
 
   .suggestion-description {
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
+
+    padding-left: @item-side-padding;
+    padding-right: @item-side-padding;
+    line-height: @row-line-height;
+    height: @row-line-height;
+
+    background: darken(@overlay-background-color, 5%);
+    border-radius: 0 0 @component-border-radius @component-border-radius;
   }
 
-  hr {
-    margin: 4px;
-    height: 1px;
-    background-color: @text-color-subtle;
-    color: @text-color-subtle;
+  .suggestion-description-content {
+    font-size: @font-size-small;
   }
 
   input {
@@ -116,7 +125,7 @@ autocomplete-suggestion-list {
     padding-right: @item-padding;
     vertical-align: middle;
 
-    font-size: .9em;
+    font-size: @font-size-small;
     color: @text-color-subtle;
 
     &:empty {
@@ -129,7 +138,7 @@ autocomplete-suggestion-list {
     padding-left: @item-padding;
     padding-right: @item-side-padding;
 
-    font-size: .9em;
+    font-size: @font-size-small;
     color: @text-color-subtle;
 
     &:empty {

--- a/styles/autocomplete.less
+++ b/styles/autocomplete.less
@@ -24,21 +24,19 @@ autocomplete-suggestion-list.select-list.popover-list {
   }
 
   .suggestion-description {
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    overflow: hidden;
-
+    padding: 5px 0;
     padding-left: @item-side-padding;
     padding-right: @item-side-padding;
-    line-height: @row-line-height;
-    height: @row-line-height;
+    min-height: @row-line-height;
+    line-height: 1.3;
 
     background: darken(@overlay-background-color, 5%);
     border-radius: 0 0 @component-border-radius @component-border-radius;
   }
 
   .suggestion-description-content {
-    font-size: @font-size-small;
+    font-size: @font-size + 1px;
+    font-family: @font-family;
   }
 
   input {

--- a/styles/autocomplete.less
+++ b/styles/autocomplete.less
@@ -17,6 +17,20 @@ autocomplete-suggestion-list.select-list.popover-list {
   min-width: 200px;
   overflow-y: auto;
   padding: 0;
+  max-width: 700px;
+
+  .docstring {
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
+
+  hr {
+    margin: 4px;
+    height: 1px;
+    background-color: @text-color-subtle;
+    color: @text-color-subtle;
+  }
 
   input {
     position: absolute;

--- a/styles/autocomplete.less
+++ b/styles/autocomplete.less
@@ -19,7 +19,7 @@ autocomplete-suggestion-list.select-list.popover-list {
   padding: 0;
   max-width: 700px;
 
-  .docstring {
+  .suggestion-description {
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;


### PR DESCRIPTION
This is a continuation of #356. My work adds on with:

* Always display at the bottom of the list, even when scrolling
* Style the description
* Add a `descriptionMoreURL` option to add a more link
* Specs 

After using it and messing with it, I made a couple new decisions:

* Instead of a single line, I want to allow multiline initially. Hopefully people keep things reasonable
* Rather than markdown, authors can specify a `descriptionMoreURL` option to their suggestions. When this is present, it will display the more link. This should keep things uniform. 

Light:

![light-1line](https://cloud.githubusercontent.com/assets/69169/7126687/28850b48-e1f0-11e4-8204-29ab8f727d36.png)
![light-2lines](https://cloud.githubusercontent.com/assets/69169/7126684/288176f4-e1f0-11e4-89cf-81b4f2215c92.png)

Dark: 

![dark-1line](https://cloud.githubusercontent.com/assets/69169/7126686/28840bee-e1f0-11e4-9f9e-b9d53ccafdfd.png)
![dark-2lines](https://cloud.githubusercontent.com/assets/69169/7126685/28841080-e1f0-11e4-9d61-7f6adf197cef.png)

Closes #356 
Closes #209