### PR TITLE
SymbolProvider: No longer rengenerate the symbol list when saving or switching buffers

### DIFF
--- a/lib/symbol-provider.coffee
+++ b/lib/symbol-provider.coffee
@@ -57,7 +57,7 @@ class SymbolProvider
       index = @getWatchedEditorIndex(editor)
       editors = @watchedBuffers[editor.getPath()]?.editors
       editors.splice(index, 1) if index > -1
-      editorSubscriptions.destroy()
+      editorSubscriptions.dispose()
 
     if @watchedBuffers[bufferPath]?
       @watchedBuffers[bufferPath].editors.push(editor)
@@ -74,6 +74,13 @@ class SymbolProvider
         bufferPath = buffer.getPath()
         editor = @watchedBuffers[bufferPath].editors[0]
         @symbolStore.addTokensInBufferRange(editor, newRange)
+
+      bufferSubscriptions.add buffer.onDidChangePath =>
+        oldBufferPath = bufferPath
+        bufferPath = buffer.getPath()
+        @watchedBuffers[bufferPath] = @watchedBuffers[oldBufferPath]
+        @symbolStore.updateForPathChange(oldBufferPath, bufferPath)
+        delete @watchedBuffers[oldBufferPath]
 
       bufferSubscriptions.add buffer.onDidDestroy =>
         bufferPath = buffer.getPath()

--- a/lib/symbol-provider.coffee
+++ b/lib/symbol-provider.coffee
@@ -57,6 +57,7 @@ class SymbolProvider
       index = @getWatchedEditorIndex(editor)
       editors = @watchedBuffers[editor.getPath()]?.editors
       editors.splice(index, 1) if index > -1
+      editorSubscriptions.destroy()
 
     if @watchedBuffers[bufferPath]?
       @watchedBuffers[bufferPath].editors.push(editor)

--- a/lib/symbol-provider.coffee
+++ b/lib/symbol-provider.coffee
@@ -43,12 +43,12 @@ class SymbolProvider
     @subscriptions.add(atom.config.observe('autocomplete-plus.minimumWordLength', (@minimumWordLength) => ))
     @subscriptions.add(atom.config.observe('autocomplete-plus.includeCompletionsFromAllBuffers', (@includeCompletionsFromAllBuffers) => ))
     @subscriptions.add(atom.workspace.observeActivePaneItem(@updateCurrentEditor))
-    @subscriptions.add(atom.workspace.observeTextEditors(@watchTextEditor))
+    @subscriptions.add(atom.workspace.observeTextEditors(@watchEditor))
 
   dispose: =>
     @subscriptions.dispose()
 
-  watchTextEditor: (editor) =>
+  watchEditor: (editor) =>
     bufferPath = editor.getPath()
     editorSubscriptions = new CompositeDisposable
     editorSubscriptions.add editor.displayBuffer.onDidTokenize =>
@@ -98,8 +98,7 @@ class SymbolProvider
     @watchedBuffers[buffer.getPath()]?
 
   getWatchedEditorIndex: (editor) ->
-    editors = @watchedBuffers[editor.getPath()]?.editors
-    if editors?
+    if editors = @watchedBuffers[editor.getPath()]?.editors
       editors.indexOf(editor)
     else
       -1

--- a/lib/symbol-provider.coffee
+++ b/lib/symbol-provider.coffee
@@ -180,8 +180,8 @@ class SymbolProvider
     wordUnderCursor = @wordAtBufferPosition(options)
     @buildConfigIfScopeChanged(options)
 
-    editorPath = if @includeCompletionsFromAllBuffers then null else @editor.getPath()
-    symbolList = @symbolStore.symbolsForConfig(@config, editorPath, wordUnderCursor)
+    bufferPath = if @includeCompletionsFromAllBuffers then null else @editor.getPath()
+    symbolList = @symbolStore.symbolsForConfig(@config, bufferPath, wordUnderCursor)
 
     words =
       if atom.config.get("autocomplete-plus.strictMatching")
@@ -199,13 +199,13 @@ class SymbolProvider
     suffix = lineFromPosition.match(@beginningOfLineWordRegex)?[0] or ''
     prefix + suffix
 
-  fuzzyFilter: (symbolList, editorPath, {bufferPosition, prefix}) ->
+  fuzzyFilter: (symbolList, bufferPath, {bufferPosition, prefix}) ->
     # Probably inefficient to do a linear search
     candidates = []
     for symbol in symbolList
       continue unless prefix[0].toLowerCase() is symbol.text[0].toLowerCase() # must match the first char!
       score = fuzzaldrin.score(symbol.text, prefix)
-      score *= @getLocalityScore(bufferPosition, symbol.bufferRowsForEditorPath?(editorPath))
+      score *= @getLocalityScore(bufferPosition, symbol.bufferRowsForBufferPath?(bufferPath))
       candidates.push({symbol, score, locality, rowDifference}) if score > 0
 
     candidates.sort(@symbolSortReverseIterator)
@@ -250,10 +250,10 @@ class SymbolProvider
   cacheSymbolsFromEditor: (editor, tokenizedLines) ->
     tokenizedLines ?= @getTokenizedLines(editor)
 
-    editorPath = editor.getPath()
+    bufferPath = editor.getPath()
     for {tokens}, bufferRow in tokenizedLines
       for token in tokens
-        @symbolStore.addToken(token, editorPath, bufferRow, @minimumWordLength)
+        @symbolStore.addToken(token, bufferPath, bufferRow, @minimumWordLength)
     return
 
   getTokenizedLines: (editor) ->

--- a/lib/symbol-store.coffee
+++ b/lib/symbol-store.coffee
@@ -29,6 +29,10 @@ class Symbol
       @count -= editorPathCount
       delete @metadataByPath[editorPath]
 
+  updateForPathChange: (oldPath, newPath) ->
+    @metadataByPath[newPath] = @metadataByPath[oldPath]
+    delete @metadataByPath[oldPath]
+
   adjustBufferRows: (editorPath, adjustmentStartRow, adjustmentDelta) ->
     bufferRows = @metadataByPath[editorPath]?.bufferRows
     return unless bufferRows?
@@ -134,6 +138,11 @@ class SymbolStore
     adjustmentDelta = newRange.getRowCount() - oldRange.getRowCount()
     for key, symbol of @symbolMap
       symbol.adjustBufferRows(editor.getPath(), adjustmentStartRow, adjustmentDelta)
+    return
+
+  updateForPathChange: (oldPath, newPath) ->
+    for key, symbol of @symbolMap
+      symbol.updateForPathChange(oldPath, newPath)
     return
 
   addToken: (token, editorPath, bufferRow) =>

--- a/lib/symbol-store.coffee
+++ b/lib/symbol-store.coffee
@@ -27,7 +27,7 @@ class Symbol
     editorPathCount = @countForEditorPath(editorPath)
     if editorPathCount > 0
       @count -= editorPathCount
-      @metadataByPath[editorPath] = null
+      delete @metadataByPath[editorPath]
 
   adjustBufferRows: (editorPath, adjustmentStartRow, adjustmentDelta) ->
     bufferRows = @metadataByPath[editorPath]?.bufferRows

--- a/lib/symbol-store.coffee
+++ b/lib/symbol-store.coffee
@@ -19,8 +19,11 @@ class Symbol
   adjustBufferRows: (editorPath, adjustmentStartRow, adjustmentDelta) ->
     bufferRows = @metadataByPath[editorPath].bufferRows
     return unless bufferRows?
-    for bufferRow, index in bufferRows
-      bufferRows[index] += adjustmentDelta if bufferRow >= adjustmentStartRow
+    index = binaryIndexOf(bufferRows, adjustmentStartRow)
+    length = bufferRows.length
+    while index < length
+      bufferRows[index] += adjustmentDelta
+      index++
     return
 
   addInstance: (editorPath, bufferRow, scopeChain) ->

--- a/spec/symbol-provider-spec.coffee
+++ b/spec/symbol-provider-spec.coffee
@@ -112,24 +112,24 @@ describe 'SymbolProvider', ->
     editor.setText('function abc(){}\nfunction abc(){}')
     advanceClock(provider.changeUpdateDelay)
     suggestion = suggestionForWord(provider.symbolStore, 'abc')
-    expect(suggestion.bufferRowsForEditorPath(editor.getPath())).toEqual [0, 1]
+    expect(suggestion.bufferRowsForBufferPath(editor.getPath())).toEqual [0, 1]
 
     editor.setCursorBufferPosition([2, 100])
     editor.insertText('\n\nfunction omg(){}; function omg(){}')
     advanceClock(provider.changeUpdateDelay)
     suggestion = suggestionForWord(provider.symbolStore, 'omg')
-    expect(suggestion.bufferRowsForEditorPath(editor.getPath())).toEqual [3, 3]
+    expect(suggestion.bufferRowsForBufferPath(editor.getPath())).toEqual [3, 3]
 
     editor.selectLeft(16)
     editor.backspace()
     advanceClock(provider.changeUpdateDelay)
     suggestion = suggestionForWord(provider.symbolStore, 'omg')
-    expect(suggestion.bufferRowsForEditorPath(editor.getPath())).toEqual [3]
+    expect(suggestion.bufferRowsForBufferPath(editor.getPath())).toEqual [3]
 
     editor.insertText('\nfunction omg(){}')
     advanceClock(provider.changeUpdateDelay)
     suggestion = suggestionForWord(provider.symbolStore, 'omg')
-    expect(suggestion.bufferRowsForEditorPath(editor.getPath())).toEqual [3, 4]
+    expect(suggestion.bufferRowsForBufferPath(editor.getPath())).toEqual [3, 4]
 
     editor.setText('')
     advanceClock(provider.changeUpdateDelay)
@@ -148,7 +148,7 @@ describe 'SymbolProvider', ->
     # rows when there are several changes before the change delay is
     # triggered. So we're just making sure the row is in there.
     suggestion = suggestionForWord(provider.symbolStore, 'abc')
-    expect(suggestion.bufferRowsForEditorPath(editor.getPath())).toContain 3
+    expect(suggestion.bufferRowsForBufferPath(editor.getPath())).toContain 3
 
   it "does not output suggestions from the other buffer", ->
     [results, coffeeEditor] = []

--- a/spec/symbol-provider-spec.coffee
+++ b/spec/symbol-provider-spec.coffee
@@ -163,6 +163,26 @@ describe 'SymbolProvider', ->
       advanceClock 1 # build the new wordlist
       expect(suggestionsForPrefix(provider, coffeeEditor, 'item')).toHaveLength 0
 
+  describe "when the editor's path changes", ->
+    it "continues to track changes on the new path", ->
+      buffer = editor.getBuffer()
+
+      expect(provider.isWatchingEditor(editor)).toBe true
+      expect(provider.isWatchingBuffer(buffer)).toBe true
+      expect(suggestionsForPrefix(provider, editor, 'qu')).toContain 'quicksort'
+
+      buffer.setPath('cats.js')
+
+      expect(provider.isWatchingEditor(editor)).toBe true
+      expect(provider.isWatchingBuffer(buffer)).toBe true
+
+      editor.moveToBottom()
+      editor.moveToBeginningOfLine()
+      expect(suggestionsForPrefix(provider, editor, 'qu')).toContain 'quicksort'
+      expect(suggestionsForPrefix(provider, editor, 'anew')).not.toContain 'aNewFunction'
+      editor.insertText('function aNewFunction(){};')
+      expect(suggestionsForPrefix(provider, editor, 'anew')).toContain 'aNewFunction'
+
   describe "when multiple editors track the same buffer", ->
     [leftPane, rightPane, rightEditor] = []
     beforeEach ->

--- a/spec/symbol-store-spec.coffee
+++ b/spec/symbol-store-spec.coffee
@@ -43,7 +43,7 @@ describe 'SymbolStore', ->
 
   it "keeps track of token buffer rows after changes to the buffer", ->
     getSymbolBufferRows = (symbol) ->
-      store.getSymbol(symbol).bufferRowsForEditorPath(editor.getPath())
+      store.getSymbol(symbol).bufferRowsForBufferPath(editor.getPath())
 
     editor.setText('\n\nabc = ->')
     expect(getSymbolBufferRows('abc')).toEqual [2]
@@ -196,7 +196,7 @@ describe 'SymbolStore', ->
         expect(symbols[2].text).toBe 'wow'
 
     describe "::clear()", ->
-      describe "when an editorPaths is specified", ->
+      describe "when an bufferPaths is specified", ->
         it "removes only the path specified", ->
           config =
             stuff:

--- a/spec/symbol-store-spec.coffee
+++ b/spec/symbol-store-spec.coffee
@@ -172,3 +172,45 @@ describe 'SymbolStore', ->
       expect(symbols.length).toBe 1
       expect(symbols[0].text).toBe 'abc'
       expect(symbols[0].type).toBe 'newtype'
+
+  describe "::clear()", ->
+    describe "when an editorPaths is specified", ->
+      beforeEach ->
+        store.addToken({value: 'one', scopes: ['source.coffee']}, 'one.txt', 1)
+        store.addToken({value: 'ok', scopes: ['source.coffee']}, 'one.txt', 1)
+        store.addToken({value: 'wow', scopes: ['source.coffee']}, 'one.txt', 2)
+        store.addToken({value: 'wow', scopes: ['source.coffee']}, 'one.txt', 2)
+
+        store.addToken({value: 'two', scopes: ['source.coffee']}, 'two.txt', 1)
+        store.addToken({value: 'ok', scopes: ['source.coffee']}, 'two.txt', 1)
+        store.addToken({value: 'wow', scopes: ['source.coffee']}, 'two.txt', 2)
+
+      it "removes only the path specified", ->
+        config =
+          stuff:
+            selectors: Selector.create('.source')
+            priority: 1
+
+        symbols = store.symbolsForConfig(config)
+        expect(symbols).toHaveLength 4
+        expect(symbols[0].text).toBe 'one'
+        expect(symbols[1].text).toBe 'ok'
+        expect(symbols[2].text).toBe 'wow'
+        expect(symbols[3].text).toBe 'two'
+
+        expect(store.getSymbol('one').getCount()).toBe 1
+        expect(store.getSymbol('two').getCount()).toBe 1
+        expect(store.getSymbol('ok').getCount()).toBe 2
+        expect(store.getSymbol('wow').getCount()).toBe 3
+
+        store.clear('one.txt')
+        symbols = store.symbolsForConfig(config)
+        expect(symbols).toHaveLength 3
+        expect(symbols[0].text).toBe 'ok'
+        expect(symbols[1].text).toBe 'wow'
+        expect(symbols[2].text).toBe 'two'
+
+        expect(store.getSymbol('one')).toBeUndefined()
+        expect(store.getSymbol('two').getCount()).toBe 1
+        expect(store.getSymbol('ok').getCount()).toBe 1
+        expect(store.getSymbol('wow').getCount()).toBe 1

--- a/spec/symbol-store-spec.coffee
+++ b/spec/symbol-store-spec.coffee
@@ -173,44 +173,55 @@ describe 'SymbolStore', ->
       expect(symbols[0].text).toBe 'abc'
       expect(symbols[0].type).toBe 'newtype'
 
-  describe "::clear()", ->
-    describe "when an editorPaths is specified", ->
-      beforeEach ->
-        store.addToken({value: 'one', scopes: ['source.coffee']}, 'one.txt', 1)
-        store.addToken({value: 'ok', scopes: ['source.coffee']}, 'one.txt', 1)
-        store.addToken({value: 'wow', scopes: ['source.coffee']}, 'one.txt', 2)
-        store.addToken({value: 'wow', scopes: ['source.coffee']}, 'one.txt', 2)
+  describe "when there are multiple files with tokens in the store", ->
+    beforeEach ->
+      store.addToken({value: 'one', scopes: ['source.coffee']}, 'one.txt', 1)
+      store.addToken({value: 'ok', scopes: ['source.coffee']}, 'one.txt', 1)
+      store.addToken({value: 'wow', scopes: ['source.coffee']}, 'one.txt', 2)
+      store.addToken({value: 'wow', scopes: ['source.coffee']}, 'one.txt', 2)
 
-        store.addToken({value: 'two', scopes: ['source.coffee']}, 'two.txt', 1)
-        store.addToken({value: 'ok', scopes: ['source.coffee']}, 'two.txt', 1)
-        store.addToken({value: 'wow', scopes: ['source.coffee']}, 'two.txt', 2)
+      store.addToken({value: 'two', scopes: ['source.coffee']}, 'two.txt', 1)
+      store.addToken({value: 'ok', scopes: ['source.coffee']}, 'two.txt', 1)
+      store.addToken({value: 'wow', scopes: ['source.coffee']}, 'two.txt', 2)
 
-      it "removes only the path specified", ->
+    describe "::symbolsForConfig(config)", ->
+      it "returs symbols based on path", ->
         config =
           stuff:
             selectors: Selector.create('.source')
-            priority: 1
-
-        symbols = store.symbolsForConfig(config)
-        expect(symbols).toHaveLength 4
+        symbols = store.symbolsForConfig(config, 'one.txt')
+        expect(symbols).toHaveLength 3
         expect(symbols[0].text).toBe 'one'
         expect(symbols[1].text).toBe 'ok'
         expect(symbols[2].text).toBe 'wow'
-        expect(symbols[3].text).toBe 'two'
 
-        expect(store.getSymbol('one').getCount()).toBe 1
-        expect(store.getSymbol('two').getCount()).toBe 1
-        expect(store.getSymbol('ok').getCount()).toBe 2
-        expect(store.getSymbol('wow').getCount()).toBe 3
+    describe "::clear()", ->
+      describe "when an editorPaths is specified", ->
+        it "removes only the path specified", ->
+          config =
+            stuff:
+              selectors: Selector.create('.source')
 
-        store.clear('one.txt')
-        symbols = store.symbolsForConfig(config)
-        expect(symbols).toHaveLength 3
-        expect(symbols[0].text).toBe 'ok'
-        expect(symbols[1].text).toBe 'wow'
-        expect(symbols[2].text).toBe 'two'
+          symbols = store.symbolsForConfig(config)
+          expect(symbols).toHaveLength 4
+          expect(symbols[0].text).toBe 'one'
+          expect(symbols[1].text).toBe 'ok'
+          expect(symbols[2].text).toBe 'wow'
+          expect(symbols[3].text).toBe 'two'
 
-        expect(store.getSymbol('one')).toBeUndefined()
-        expect(store.getSymbol('two').getCount()).toBe 1
-        expect(store.getSymbol('ok').getCount()).toBe 1
-        expect(store.getSymbol('wow').getCount()).toBe 1
+          expect(store.getSymbol('one').getCount()).toBe 1
+          expect(store.getSymbol('two').getCount()).toBe 1
+          expect(store.getSymbol('ok').getCount()).toBe 2
+          expect(store.getSymbol('wow').getCount()).toBe 3
+
+          store.clear('one.txt')
+          symbols = store.symbolsForConfig(config)
+          expect(symbols).toHaveLength 3
+          expect(symbols[0].text).toBe 'ok'
+          expect(symbols[1].text).toBe 'wow'
+          expect(symbols[2].text).toBe 'two'
+
+          expect(store.getSymbol('one')).toBeUndefined()
+          expect(store.getSymbol('two').getCount()).toBe 1
+          expect(store.getSymbol('ok').getCount()).toBe 1
+          expect(store.getSymbol('wow').getCount()).toBe 1

--- a/spec/symbol-store-spec.coffee
+++ b/spec/symbol-store-spec.coffee
@@ -16,8 +16,9 @@ describe 'SymbolStore', ->
 
       editor.setText('')
       buffer = editor.getBuffer()
-      buffer.onWillChange ({oldRange}) ->
+      buffer.onWillChange ({oldRange, newRange}) ->
         store.removeTokensInBufferRange(editor, oldRange)
+        store.adjustBufferRows(editor, oldRange, newRange)
       buffer.onDidChange ({newRange}) ->
         store.addTokensInBufferRange(editor, newRange)
 
@@ -39,6 +40,43 @@ describe 'SymbolStore', ->
     editor.setText('\n\nabc = ->')
     expect(store.getLength()).toBe 1
     expect(store.getSymbol('abc').getCount()).toBe 1
+
+  it "keeps track of token buffer rows after changes to the buffer", ->
+    getSymbolBufferRows = (symbol) ->
+      store.getSymbol(symbol).bufferRowsForEditorPath(editor.getPath())
+
+    editor.setText('\n\nabc = ->')
+    expect(getSymbolBufferRows('abc')).toEqual [2]
+
+    editor.setCursorBufferPosition([0, 0])
+    editor.insertNewline()
+    expect(getSymbolBufferRows('abc')).toEqual [3]
+
+    editor.setText """
+      abc: ->
+        onetwo = [one, two]
+        multipleLines = 'multipleLines'
+        yeah = 'ok'
+        multipleLines += 'ok'
+    """
+    expect(getSymbolBufferRows('abc')).toEqual [0]
+    expect(getSymbolBufferRows('onetwo')).toEqual [1]
+    expect(getSymbolBufferRows('one')).toEqual [1]
+    expect(getSymbolBufferRows('two')).toEqual [1]
+    expect(getSymbolBufferRows('multipleLines')).toEqual [2, 2, 4]
+    expect(getSymbolBufferRows('yeah')).toEqual [3]
+    expect(getSymbolBufferRows('ok')).toEqual [3, 4]
+
+    editor.setSelectedBufferRange([[2, 18], [3, 13]])
+    editor.insertText("'ok'")
+
+    expect(getSymbolBufferRows('abc')).toEqual [0]
+    expect(getSymbolBufferRows('onetwo')).toEqual [1]
+    expect(getSymbolBufferRows('one')).toEqual [1]
+    expect(getSymbolBufferRows('two')).toEqual [1]
+    expect(getSymbolBufferRows('multipleLines')).toEqual [2, 3]
+    expect(store.getSymbol('yeah')).toBeUndefined()
+    expect(getSymbolBufferRows('ok')).toEqual [2, 3]
 
   describe "::symbolsForConfig(config)", ->
     it "gets a list of symbols matching the passed in configuration", ->

--- a/spec/symbol-store-spec.coffee
+++ b/spec/symbol-store-spec.coffee
@@ -78,6 +78,16 @@ describe 'SymbolStore', ->
     expect(store.getSymbol('yeah')).toBeUndefined()
     expect(getSymbolBufferRows('ok')).toEqual [2, 3]
 
+    editor.insertText("\n\nomg = 'ok'; multipleLines += 'wow'\n\n")
+
+    expect(getSymbolBufferRows('abc')).toEqual [0]
+    expect(getSymbolBufferRows('onetwo')).toEqual [1]
+    expect(getSymbolBufferRows('one')).toEqual [1]
+    expect(getSymbolBufferRows('two')).toEqual [1]
+    expect(getSymbolBufferRows('wow')).toEqual [4]
+    expect(getSymbolBufferRows('multipleLines')).toEqual [2, 4, 7]
+    expect(getSymbolBufferRows('ok')).toEqual [2, 4, 7]
+
   describe "::symbolsForConfig(config)", ->
     it "gets a list of symbols matching the passed in configuration", ->
       config =


### PR DESCRIPTION
With this PR, the list of symbols will only be generated once for each open file: on file open (welllll, on retokenization too, but that is infrequent). 

This keeps the `SymbolStore` up to date with all the symbols for all open buffers as the open buffers change; it keeps track of the position (buffer row) of each symbol in each open file. One `Symbol` object is stored for each unique symbol.

Why do this? Regeneration on save and when switching buffers is laggy. It gets even more laggy when there are multiple open largish files and you have `includeAllOpenBuffers` on. Reading the symbols once, then consuming the localized changes is ideal. 

Note that this is optimized for returning the results of all open buffers: It tracks all open buffers all the time. It tracks all of them because changes might come in behind the scenes (git pull? branch change?), and one change behind the `SymbolStore`s back may make for irreconcilable state. 
 
cc @nathansobo as this was something you wanted. Tracking the bufferRows was surprisingly easy and efficient.

TODO

* [x] Properly track bufferRows in the store
* [x] Remove the regeneration on save and active pane item
* [x] Make sure this works with splits, closing splits, etc. Seems like it might be able to get in a state with a legit buffer with destroyed editor.