### PR TITLE
Accept `displayText` property in suggestion object

### DIFF
--- a/lib/suggestion-list-element.coffee
+++ b/lib/suggestion-list-element.coffee
@@ -200,7 +200,7 @@ class SuggestionListElement extends HTMLElement
     if @suggestionListFollows is 'Word'
       @style['margin-left'] = "#{@uiProps.marginLeft}px"
 
-  renderItem: ({iconHTML, type, snippet, text, className, replacementPrefix, leftLabel, leftLabelHTML, rightLabel, rightLabelHTML}, index) ->
+  renderItem: ({iconHTML, type, snippet, text, displayText, className, replacementPrefix, leftLabel, leftLabelHTML, rightLabel, rightLabelHTML}, index) ->
     li = @ol.childNodes[index]
     unless li
       li = document.createElement('li')
@@ -227,7 +227,7 @@ class SuggestionListElement extends HTMLElement
       typeIcon.classList.add(type) if type
 
     wordSpan = li.querySelector('.word')
-    wordSpan.innerHTML = @getDisplayHTML(text, snippet, replacementPrefix)
+    wordSpan.innerHTML = @getDisplayHTML(text, snippet, displayText, replacementPrefix)
 
     leftLabelSpan = li.querySelector('.left-label')
     if leftLabelHTML?
@@ -245,9 +245,11 @@ class SuggestionListElement extends HTMLElement
     else
       rightLabelSpan.textContent = ''
 
-  getDisplayHTML: (text, snippet, replacementPrefix) ->
+  getDisplayHTML: (text, snippet, displayText, replacementPrefix) ->
     replacementText = text
-    if typeof snippet is 'string'
+    if typeof displayText is 'string'
+      replacementText = displayText
+    else if typeof snippet is 'string'
       replacementText = @removeEmptySnippets(snippet)
       snippets = @snippetParser.findSnippets(replacementText)
       replacementText = @removeSnippetsFromText(snippets, replacementText)

--- a/lib/symbol-provider.coffee
+++ b/lib/symbol-provider.coffee
@@ -76,8 +76,8 @@ class SymbolProvider
         @symbolStore.addTokensInBufferRange(editor, newRange)
 
       bufferSubscriptions.add buffer.onDidChangePath =>
+        return unless @watchedBuffers[bufferPath]?
         oldBufferPath = bufferPath
-        return unless @watchedBuffers[oldBufferPath]?
         bufferPath = buffer.getPath()
         @watchedBuffers[bufferPath] = @watchedBuffers[oldBufferPath]
         @symbolStore.updateForPathChange(oldBufferPath, bufferPath)

--- a/spec/provider-api-spec.coffee
+++ b/spec/provider-api-spec.coffee
@@ -96,6 +96,26 @@ describe 'Provider API', ->
         expect(suggestionListView.querySelector('.suggestion-description-content')).toHaveText('There be documentation')
         expect(suggestionListView.querySelector('.suggestion-description-more-link').style.display).toBe 'none'
 
+    it "favors the `displayText` over text or snippet suggestion options", ->
+      testProvider =
+        selector: '.source.js, .source.coffee'
+        getSuggestions: (options) ->
+          [
+            text: 'ohai',
+            snippet: 'snippet'
+            displayText: 'displayOHAI'
+            replacementPrefix: 'o',
+            rightLabelHTML: '<span style="color: red">ohai</span>',
+            description: 'There be documentation'
+          ]
+      registration = atom.packages.serviceHub.provide('autocomplete.provider', '2.0.0', testProvider)
+
+      triggerAutocompletion(editor, true, 'o')
+
+      runs ->
+        suggestionListView = atom.views.getView(autocompleteManager.suggestionList)
+        expect(suggestionListView.querySelector('.word')).toHaveText('displayOHAI')
+
     it 'correctly displays the suggestion description and More link', ->
       testProvider =
         selector: '.source.js, .source.coffee'

--- a/spec/suggestion-list-element-spec.coffee
+++ b/spec/suggestion-list-element-spec.coffee
@@ -12,79 +12,87 @@ describe 'Suggestion List Element', ->
     suggestionListElement = null
 
   describe 'getDisplayHTML', ->
+    it 'uses displayText over text or snippet', ->
+      text = 'abcd()'
+      snippet = undefined
+      displayText = 'acd'
+      replacementPrefix = 'a'
+      html = suggestionListElement.getDisplayHTML(text, snippet, displayText, replacementPrefix)
+      expect(html).toBe('<span class="character-match">a</span>cd')
+
     it 'handles the empty string in the text field', ->
       text = ''
       snippet = undefined
       replacementPrefix = 'a'
-      html = suggestionListElement.getDisplayHTML(text, snippet, replacementPrefix)
+      html = suggestionListElement.getDisplayHTML(text, snippet, null, replacementPrefix)
       expect(html).toBe('')
 
     it 'handles the empty string in the snippet field', ->
       text = undefined
       snippet = ''
       replacementPrefix = 'a'
-      html = suggestionListElement.getDisplayHTML(text, snippet, replacementPrefix)
+      html = suggestionListElement.getDisplayHTML(text, snippet, null, replacementPrefix)
       expect(html).toBe('')
 
     it 'handles an empty prefix', ->
       text = undefined
       snippet = 'abc'
       replacementPrefix = ''
-      html = suggestionListElement.getDisplayHTML(text, snippet, replacementPrefix)
+      html = suggestionListElement.getDisplayHTML(text, snippet, null, replacementPrefix)
       expect(html).toBe('abc')
 
     it 'outputs correct html when there are no snippets in the snippet field', ->
       text = ''
       snippet = 'abc(d, e)f'
       replacementPrefix = 'a'
-      html = suggestionListElement.getDisplayHTML(text, snippet, replacementPrefix)
+      html = suggestionListElement.getDisplayHTML(text, snippet, null, replacementPrefix)
       expect(html).toBe('<span class="character-match">a</span>bc(d, e)f')
 
     it 'outputs correct html when there are not character matches', ->
       text = ''
       snippet = 'abc(d, e)f'
       replacementPrefix = 'omg'
-      html = suggestionListElement.getDisplayHTML(text, snippet, replacementPrefix)
+      html = suggestionListElement.getDisplayHTML(text, snippet, null, replacementPrefix)
       expect(html).toBe('abc(d, e)f')
 
     it 'outputs correct html when the text field is used', ->
       text = 'abc(d, e)f'
       snippet = undefined
       replacementPrefix = 'a'
-      html = suggestionListElement.getDisplayHTML(text, snippet, replacementPrefix)
+      html = suggestionListElement.getDisplayHTML(text, snippet, null, replacementPrefix)
       expect(html).toBe('<span class="character-match">a</span>bc(d, e)f')
 
     it 'replaces a snippet with no escaped right braces', ->
       text = ''
       snippet = 'abc(${1:d}, ${2:e})f'
       replacementPrefix = 'a'
-      html = suggestionListElement.getDisplayHTML(text, snippet, replacementPrefix)
+      html = suggestionListElement.getDisplayHTML(text, snippet, null, replacementPrefix)
       expect(html).toBe('<span class="character-match">a</span>bc(<span class="snippet-completion">d</span>, <span class="snippet-completion">e</span>)f')
 
     it 'replaces a snippet with no escaped right braces', ->
       text = ''
       snippet = 'text(${1:ab}, ${2:cd})'
       replacementPrefix = 'ta'
-      html = suggestionListElement.getDisplayHTML(text, snippet, replacementPrefix)
+      html = suggestionListElement.getDisplayHTML(text, snippet, null, replacementPrefix)
       expect(html).toBe('<span class="character-match">t</span>ext(<span class="snippet-completion"><span class="character-match">a</span>b</span>, <span class="snippet-completion">cd</span>)')
 
     it 'replaces a snippet with escaped right braces', ->
       text = ''
       snippet = 'abc(${1:d}, ${2:e})f ${3:interface{\\}}'
       replacementPrefix = 'a'
-      expect(suggestionListElement.getDisplayHTML(text, snippet, replacementPrefix)).toBe('<span class="character-match">a</span>bc(<span class="snippet-completion">d</span>, <span class="snippet-completion">e</span>)f <span class="snippet-completion">interface{}</span>')
+      expect(suggestionListElement.getDisplayHTML(text, snippet, null, replacementPrefix)).toBe('<span class="character-match">a</span>bc(<span class="snippet-completion">d</span>, <span class="snippet-completion">e</span>)f <span class="snippet-completion">interface{}</span>')
 
     it 'replaces a snippet with escaped multiple right braces', ->
       text = ''
       snippet = 'abc(${1:d}, ${2:something{ok\\}}, ${3:e})f ${4:interface{\\}}'
       replacementPrefix = 'a'
-      expect(suggestionListElement.getDisplayHTML(text, snippet, replacementPrefix)).toBe('<span class="character-match">a</span>bc(<span class="snippet-completion">d</span>, <span class="snippet-completion">something{ok}</span>, <span class="snippet-completion">e</span>)f <span class="snippet-completion">interface{}</span>')
+      expect(suggestionListElement.getDisplayHTML(text, snippet, null, replacementPrefix)).toBe('<span class="character-match">a</span>bc(<span class="snippet-completion">d</span>, <span class="snippet-completion">something{ok}</span>, <span class="snippet-completion">e</span>)f <span class="snippet-completion">interface{}</span>')
 
     it 'replaces a snippet with elements that have no text', ->
       text = ''
       snippet = 'abc(${1:d}, ${2:e})f${3}'
       replacementPrefix = 'a'
-      expect(suggestionListElement.getDisplayHTML(text, snippet, replacementPrefix)).toBe('<span class="character-match">a</span>bc(<span class="snippet-completion">d</span>, <span class="snippet-completion">e</span>)f')
+      expect(suggestionListElement.getDisplayHTML(text, snippet, null, replacementPrefix)).toBe('<span class="character-match">a</span>bc(<span class="snippet-completion">d</span>, <span class="snippet-completion">e</span>)f')
 
   describe 'findCharacterMatches', ->
     assertMatches = (text, replacementPrefix, truthyIndices) ->


### PR DESCRIPTION
The `displayText` will take display precedent over both `text` and `snippet`.