### PR TITLE
Move symbol config to autocomplete.symbols

### DIFF
--- a/lib/symbol-provider.coffee
+++ b/lib/symbol-provider.coffee
@@ -117,11 +117,15 @@ class SymbolProvider
 
   buildConfig: (scopeDescriptor) ->
     @config = {}
-    allConfigEntries = @settingsForScopeDescriptor(scopeDescriptor, 'editor.completions')
+    legacyCompletions = @settingsForScopeDescriptor(scopeDescriptor, 'editor.completions')
+    allConfigEntries = @settingsForScopeDescriptor(scopeDescriptor, 'autocomplete.symbols')
 
     # Config entries are reverse sorted in order of specificity. We want most
     # specific to win; this simplifies the loop.
     allConfigEntries.reverse()
+
+    for {value} in legacyCompletions
+      @addLegacyConfigEntry(value) if Array.isArray(value) and value.length
 
     addedConfigEntry = false
     for {value} in allConfigEntries

--- a/lib/symbol-provider.coffee
+++ b/lib/symbol-provider.coffee
@@ -129,9 +129,7 @@ class SymbolProvider
 
     addedConfigEntry = false
     for {value} in allConfigEntries
-      if Array.isArray(value)
-        @addLegacyConfigEntry(value) if value.length
-      else if typeof value is 'object'
+      if not Array.isArray(value) and typeof value is 'object'
         @addConfigEntry(value)
         addedConfigEntry = true
 

--- a/spec/symbol-provider-spec.coffee
+++ b/spec/symbol-provider-spec.coffee
@@ -256,7 +256,7 @@ describe 'SymbolProvider', ->
       results = suggestionsForPrefix(provider, editor, 'item')
       expect(results[0]).toBe 'items'
 
-  describe "when the completions changes between scopes", ->
+  describe "when the autocomplete.symbols changes between scopes", ->
     beforeEach ->
       editor.setText '''
         // in-a-comment
@@ -271,8 +271,8 @@ describe 'SymbolProvider', ->
         instring:
           selector: '.string'
 
-      atom.config.set('editor.completions', commentConfig, scopeSelector: '.source.js .comment')
-      atom.config.set('editor.completions', stringConfig, scopeSelector: '.source.js .string')
+      atom.config.set('autocomplete.symbols', commentConfig, scopeSelector: '.source.js .comment')
+      atom.config.set('autocomplete.symbols', stringConfig, scopeSelector: '.source.js .string')
 
     it "uses the config for the scope under the cursor", ->
       # Using the comment config
@@ -296,7 +296,7 @@ describe 'SymbolProvider', ->
       expect(suggestions[0].text).toBe 'invar'
       expect(suggestions[0].type).toBe '' # the js grammar sucks :(
 
-  describe "when the completions contains a list of suggestion strings", ->
+  describe "when the config contains a list of suggestion strings", ->
     beforeEach ->
       editor.setText '// abcomment'
       commentConfig =
@@ -304,7 +304,7 @@ describe 'SymbolProvider', ->
         builtin:
           suggestions: ['abcd', 'abcde', 'abcdef']
 
-      atom.config.set('editor.completions', commentConfig, scopeSelector: '.source.js .comment')
+      atom.config.set('autocomplete.symbols', commentConfig, scopeSelector: '.source.js .comment')
 
     it "adds the suggestions to the results", ->
       # Using the comment config
@@ -316,7 +316,7 @@ describe 'SymbolProvider', ->
       expect(suggestions[1].text).toBe 'abcd'
       expect(suggestions[1].type).toBe 'builtin'
 
-  describe "when the completions contains a list of suggestion objects", ->
+  describe "when the symbols config contains a list of suggestion objects", ->
     beforeEach ->
       editor.setText '// abcomment'
       commentConfig =
@@ -327,7 +327,7 @@ describe 'SymbolProvider', ->
             {text: 'abcd', rightLabel: 'one', type: 'function'}
             []
           ]
-      atom.config.set('editor.completions', commentConfig, scopeSelector: '.source.js .comment')
+      atom.config.set('autocomplete.symbols', commentConfig, scopeSelector: '.source.js .comment')
 
     it "adds the suggestion objects to the results", ->
       # Using the comment config


### PR DESCRIPTION
It was under `editor.completions`, and now it is under `autocomplete.symbols`. 