### PR TITLE
Fix small things that came up when updating autocomplete-css and autocomplete-html

### DIFF
--- a/lib/suggestion-list.coffee
+++ b/lib/suggestion-list.coffee
@@ -75,13 +75,20 @@ class SuggestionList
     if atom.config.get('autocomplete-plus.suggestionListFollows') is 'Cursor'
       @showAtCursorPosition(editor, options)
     else
-      @showAtBeginningOfPrefix(editor, options)
+      prefix = options.prefix
+      followRawPrefix = false
+      for item in @items
+        if item.replacementPrefix?
+          prefix = item.replacementPrefix.trim()
+          followRawPrefix = true
+          break
+      @showAtBeginningOfPrefix(editor, prefix, followRawPrefix)
 
-  showAtBeginningOfPrefix: (editor, {prefix}) =>
+  showAtBeginningOfPrefix: (editor, prefix, followRawPrefix=false) =>
     return unless editor?
 
     bufferPosition = editor.getCursorBufferPosition()
-    bufferPosition = bufferPosition.translate([0, -prefix.length]) if @wordPrefixRegex.test(prefix)
+    bufferPosition = bufferPosition.translate([0, -prefix.length]) if followRawPrefix or @wordPrefixRegex.test(prefix)
 
     if @active
       unless bufferPosition.isEqual(@displayBufferPosition)

--- a/lib/symbol-provider.coffee
+++ b/lib/symbol-provider.coffee
@@ -210,8 +210,9 @@ class SymbolProvider
     # Probably inefficient to do a linear search
     candidates = []
     for symbol in symbolList
-      continue unless prefix[0].toLowerCase() is symbol.text[0].toLowerCase() # must match the first char!
-      score = fuzzaldrin.score(symbol.text, prefix)
+      text = (symbol.snippet or symbol.text)
+      continue unless prefix[0].toLowerCase() is text[0].toLowerCase() # must match the first char!
+      score = fuzzaldrin.score(text, prefix)
       score *= @getLocalityScore(bufferPosition, symbol.bufferRowsForBufferPath?(bufferPath))
       candidates.push({symbol, score, locality, rowDifference}) if score > 0
 

--- a/spec/autocomplete-manager-integration-spec.coffee
+++ b/spec/autocomplete-manager-integration-spec.coffee
@@ -44,7 +44,7 @@ describe 'Autocomplete Manager', ->
           excludeLowerPriority: true
           getSuggestions: ({prefix}) ->
             list = ['ab', 'abc', 'abcd', 'abcde']
-            ({text, replacementPrefix: prefix} for text in list)
+            ({text} for text in list)
         mainModule.consumeProvider(provider)
 
     it "calls the provider's onDidInsertSuggestion method when it exists", ->
@@ -486,9 +486,20 @@ describe 'Autocomplete Manager', ->
 
         runs ->
           overlayElement = editorView.querySelector('.autocomplete-plus')
-
           expect(overlayElement).toExist()
           expect(overlayElement.style.left).toBe pixelLeftForBufferPosition([0, 12])
+
+      it "displays the suggestion list taking into account the passed back replacementPrefix", ->
+        spyOn(provider, 'getSuggestions').andCallFake (options) ->
+          [{text: '::before', replacementPrefix: '::', leftLabel: 'void'}]
+
+        editor.insertText('xxxxxxxxxxx ab:')
+        triggerAutocompletion(editor, false, ':')
+
+        runs ->
+          overlayElement = editorView.querySelector('.autocomplete-plus')
+          expect(overlayElement).toExist()
+          expect(overlayElement.style.left).toBe pixelLeftForBufferPosition([0, 14])
 
       it "displays the suggestion list with a negative margin to align the prefix with the word-container", ->
         spyOn(provider, 'getSuggestions').andCallFake (options) ->

--- a/styles/autocomplete.less
+++ b/styles/autocomplete.less
@@ -35,9 +35,6 @@ autocomplete-suggestion-list.select-list.popover-list {
 
     background: darken(@overlay-background-color, 4%);
     border-radius: 0 0 @component-border-radius @component-border-radius;
-    white-space: nowrap;
-    overflow-x: auto;
-    overflow-y: hidden;
   }
 
   .suggestion-description-content {


### PR DESCRIPTION
### Fix prefix usage when suggestion list follows word

![screen shot 2015-04-29 at 5 55 42 pm](https://cloud.githubusercontent.com/assets/69169/7484944/c8afce78-f343-11e4-9471-b138cb6f420a.png)

to 

![screen shot 2015-05-05 at 4 27 03 pm](https://cloud.githubusercontent.com/assets/69169/7484946/cdde103a-f343-11e4-9974-bcc4b134de1a.png)

### Wrap description again

![screen shot 2015-05-05 at 4 29 51 pm](https://cloud.githubusercontent.com/assets/69169/7484954/f9fa93dc-f343-11e4-9d43-80b51e409343.png)

